### PR TITLE
Fix JSON reference files for consistency and completeness

### DIFF
--- a/docs/refs/dr3_rules.json
+++ b/docs/refs/dr3_rules.json
@@ -448,8 +448,8 @@
     "17.2_cooperation_rule": "Different players may not combine strengths; separate sieges on same castle possible",
     "17.3_zone_of_siege": {
       "17.3.1_extends": "One hex around castle in either direction from adjacent combat unit",
-      "17.3.2_fleet_restriction": "Only extends to all-sea or coastal hexes",
-      "17.3.3_land_unit_restriction": "Only extends to all-land and coastal hexes",
+      "17.3.2_fleet_restriction": "Only extends to all-sea or seashore hexes",
+      "17.3.3_land_unit_restriction": "Only extends to all-land and seashore hexes",
       "17.3.4_not_negated_by": "Friendly units to besieged castle"
     },
     "17.4_units_inside_outside": {
@@ -631,13 +631,13 @@
     "19.7_lakeshore": {
       "19.7.1_movement_cost": 1,
       "19.7.2_restriction": "Cannot cross all-lake hexsides",
-      "19.7.3_coast_crossing_exception": "A land unit does not cross the coast if it moves from one lakeshore hex to another lakeshore hex, and both lakeshore hexes have a mutual neighbour that is neither a sea, major river or a lake"
+      "19.7.3_lakeshore_crossing_exception": "A land unit does not cross the lakeshore if it moves from one lakeshore hex to another lakeshore hex, and both lakeshore hexes have a mutual neighbour that is neither a sea, major river or a lake"
     },
-    "19.8_coast": {
+    "19.8_seashore": {
       "19.8.1_movement_cost": 1,
       "19.8.2_fleet_restriction": "Cannot cross all-land hexsides",
       "19.8.3_land_restriction": "Cannot cross all-sea hexsides",
-      "19.8.4_coast_crossing_exception": "A land unit does not cross the coast if it moves from one coast hex to another coast hex, and both coastal hexes have a mutual neighbour that is neither a sea, major river or a lake"
+      "19.8.4_seashore_crossing_exception": "A land unit does not cross the seashore if it moves from one seashore hex to another seashore hex, and both seashore hexes have a mutual neighbour that is neither a sea, major river or a lake"
     },
     "19.9_open_sea": {
       "19.9.1_movement_cost": 1,
@@ -681,7 +681,7 @@
   },
 
   "20_ports": {
-    "20.1_definition": "Coastal hexes enterable by both vessels and land units",
+    "20.1_definition": "Seashore hexes enterable by both vessels and land units",
     "20.2_castle_ports": {
       "20.2.1_identifier": "Castle with anchor icon",
       "20.2.2_applies_rules": ["Castle rules", "Port rules"],
@@ -700,13 +700,13 @@
   },
 
   "21_fleet_movement": {
-    "21.1_terrain_types": ["All-sea", "Coast", "Friendly ports"],
+    "21.1_terrain_types": ["All-sea", "Seashore", "Friendly ports"],
     "21.2_cost": 1,
     "21.3_restrictions": {
       "21.3.1_enemy_fleet_hex": "Cannot enter",
       "21.3.2_allied_fleet_stacking": "Cannot end movement in same hex",
-      "21.3.3_coast_with_enemy_land": "May move through, cannot end there",
-      "21.3.4_lone_monarch_coast": "No leader fate die roll when passing through"
+      "21.3.3_seashore_with_enemy_land": "May move through, cannot end there",
+      "21.3.4_lone_monarch_seashore": "No leader fate die roll when passing through"
     }
   },
 
@@ -718,7 +718,7 @@
     },
     "22.2_embark_cost": 0,
     "22.3_debark_cost": 0,
-    "22.4_debark_locations": ["Friendly port", "Coastal hex without mountains"],
+    "22.4_debark_locations": ["Friendly port", "Seashore hex without mountains"],
     "22.5_transported_unit_movement": "Cannot otherwise move that turn",
     "22.6_fleet_continuation": "May continue moving, embarking, debarking until MP spent"
   },
@@ -999,28 +999,47 @@
 
   "30_special_kingdom_rules": {
     "30.1_trolls": {
-      "30.1.1_setup": "Four separate locations",
-      "30.1.2_regeneration": {
-        "30.1.2.1_timing": "Beginning of each turn",
-        "30.1.2.2_effect": "Replace one eliminated regular unit",
-        "30.1.2.3_in_addition_to": "Random Events replacements",
-        "30.1.2.4_placement_blocked": "If hex enemy occupied, cannot regenerate that turn",
-        "30.1.2.5_same_turn_loss": "Regular lost through Random Events cannot regenerate same turn"
+      "30.1.1_setup": "Four separate locations: Stone Face (capital), The Gathering, The Crag, The Shunned Vale",
+      "30.1.2_no_castles": "Troll locations are cities without castles. They have no intrinsic defense strength and cannot be besieged in the traditional sense. Enemy units may freely enter Troll locations.",
+      "30.1.3_monarch_start": "The Troll monarch starts at Stone Face (col 6, row 13)",
+      "30.1.4_regeneration": {
+        "30.1.4.1_timing": "Beginning of each turn",
+        "30.1.4.2_effect": "Replace one eliminated regular unit",
+        "30.1.4.3_in_addition_to": "Random Events replacements",
+        "30.1.4.4_placement_blocked": "If hex enemy occupied, cannot regenerate that turn",
+        "30.1.4.5_same_turn_loss": "Regular lost through Random Events cannot regenerate same turn"
       }
     },
     "30.2_goblins": {
       "30.2.1_nithmere_mountains_deployment": {
         "30.2.1.1_units": "Goblins labeled 'Nithmere Mts.'",
-        "30.2.1.2_location": "Mountain and pass hexes of kingdom",
+        "30.2.1.2_location": "Mountain and pass hexes of Zorn territory",
         "30.2.1.3_limit": "One per hex",
         "30.2.1.4_adjacency": "No two may be adjacent",
-        "30.2.1.5_applies_to": ["Setup", "Replacements"]
+        "30.2.1.5_applies_to": ["Setup", "Replacements"],
+        "30.2.1.6_total_units": 8,
+        "30.2.1.7_example_deployment": {
+          "30.2.1.7.1_note": "This is one valid deployment; other configurations meeting the rules are permitted",
+          "30.2.1.7.2_hexes": [[21, 7], [20, 6], [21, 5], [20, 4], [18, 4], [18, 7], [18, 0], [19, 1]]
+        }
       }
     },
     "30.3_dwarves": {
       "30.3.1_setup": "Three separate locations",
       "30.3.2_locations": ["Aws Noir", "Alzak", "Rosengg"],
       "30.3.3_unity": "All related, fight for common cause"
+    }
+  },
+
+  "31_cities_vs_castles": {
+    "31.1_distinction": "Not all faction cities are castles. Units always deploy from cities, but only cities with castle markers provide intrinsic defense.",
+    "31.2_cities_without_castles": {
+      "31.2.1_examples": ["Farnot (Hothior)", "Yando (Muetar)", "Lepers (Shucassam)", "Gorpin (Immer)", "All Troll locations"],
+      "31.2.2_effect": "These locations serve as deployment hexes but have no intrinsic defense and cannot be besieged"
+    },
+    "31.3_castle_locations": {
+      "31.3.1_identification": "Hexes with 'castle: true' terrain marker in hexmap",
+      "31.3.2_defense": "Provide intrinsic defense strength for siege rules"
     }
   }
 }

--- a/docs/refs/factions.json
+++ b/docs/refs/factions.json
@@ -36,11 +36,11 @@
           "name": "Tadafat",
           "col": 10,
           "row": 14,
-          "armies": 2,
+          "armies": 2
         }
       ],
       "totalArmies": 7,
-      "totalSeaFleets": 2,
+      "totalSeaFleets": 2
     },
     {
       "id": "mivior",
@@ -64,7 +64,7 @@
           "col": 3,
           "row": 12,
           "armies": 3,
-          "seaFleet": 1,
+          "seaFleet": 1
         },
         {
           "name": "Boliske",
@@ -82,7 +82,7 @@
         }
       ],
       "totalArmies": 9,
-      "totalSeaFleets": 4,
+      "totalSeaFleets": 4
     },
     {
       "id": "muetar",
@@ -114,8 +114,8 @@
         },
         {
           "name": "Basimar",
-          "col": 25,
-          "row": 8,
+          "col": 24,
+          "row": 9,
           "armies": 3
         },
         {
@@ -128,11 +128,11 @@
           "name": "Yando",
           "col": 19,
           "row": 16,
-          "armies": 1,
+          "armies": 1
         }
       ],
       "totalArmies": 13,
-      "totalSeaFleets": 0,
+      "totalSeaFleets": 0
     },
     {
       "id": "shucassam",
@@ -172,7 +172,7 @@
         }
       ],
       "totalArmies": 11,
-      "totalSeaFleets": 3,
+      "totalSeaFleets": 3
     },
     {
       "id": "immer",
@@ -216,7 +216,7 @@
         }
       ],
       "totalArmies": 9,
-      "totalSeaFleets": 0,
+      "totalSeaFleets": 0
     },
     {
       "id": "pon",
@@ -249,7 +249,7 @@
         }
       ],
       "totalArmies": 7,
-      "totalSeaFleets": 1,
+      "totalSeaFleets": 1
     },
     {
       "id": "rombune",
@@ -291,7 +291,7 @@
         }
       ],
       "totalArmies": 6,
-      "totalSeaFleets": 4,
+      "totalSeaFleets": 4
     },
     {
       "id": "neuth",
@@ -311,7 +311,7 @@
         }
       ],
       "totalArmies": 6,
-      "totalSeaFleets": 0,
+      "totalSeaFleets": 0
     },
     {
       "id": "zorn",
@@ -330,8 +330,9 @@
           "isCapital": true
         }
       ],
-      "totalArmies": 3,
+      "totalArmies": 11,
       "totalSeaFleets": 0,
+      "notes": "Total includes 8 Nithmere Mountain units deployed separately per rule 30.2"
     },
     {
       "id": "ghem",
@@ -346,24 +347,24 @@
           "name": "Mines of Rosengg",
           "col": 32,
           "row": 9,
-          "armies": 2,
+          "armies": 3,
           "isCapital": true
         },
         {
           "name": "Aws Noir",
           "col": 2,
           "row": 1,
-          "armies": 2,
+          "armies": 3
         },
         {
           "name": "Alzak",
           "col": 33,
           "row": 14,
-          "armies": 1
+          "armies": 2
         }
       ],
-      "totalArmies": 5,
-      "totalSeaFleets": 0,
+      "totalArmies": 8,
+      "totalSeaFleets": 0
     },
     {
       "id": "trolls",
@@ -373,6 +374,11 @@
       "capitalName": "Stone Face",
       "capitalId": "stone_face",
       "color": "#A86051",
+      "monarchStartLocation": {
+        "name": "Stone Face",
+        "col": 6,
+        "row": 13
+      },
       "cities": [
         {
           "name": "Stone Face",
@@ -402,6 +408,7 @@
       ],
       "totalArmies": 8,
       "totalSeaFleets": 0,
+      "notes": "Trolls have no castles; their locations are open terrain. See rule 30.1 for special rules."
     }
   ]
 }

--- a/docs/refs/hexmap.json
+++ b/docs/refs/hexmap.json
@@ -1557,7 +1557,7 @@
       {
         "col": 6,
         "row": 13,
-        "name": "The Face",
+        "name": "Stone Face",
         "terrain": {
           "clear": true
         },
@@ -4998,8 +4998,7 @@
         "name": "The Keep",
         "terrain": {
           "castle": true
-        },
-        "intrinsic": 2
+        }
       },
       {
         "col": 20,
@@ -6419,7 +6418,7 @@
       {
         "col": 26,
         "row": 13,
-        "name": "Crow\\'s Nest",
+        "name": "Crow's Nest",
         "terrain": {
           "castle": true
         },
@@ -8119,7 +8118,7 @@
       {
         "col": 33,
         "row": 21,
-        "name": "The Digs",
+        "name": "The Gathering",
         "terrain": {
           "clear": true
         },
@@ -8177,7 +8176,7 @@
       {
         "col": 33,
         "row": 29,
-        "name": "Wyrm\\'s Lair",
+        "name": "Wyrm's Lair",
         "terrain": {
           "scenic": true
         }
@@ -8192,7 +8191,7 @@
       {
         "col": 34,
         "row": 0,
-        "name": "Witches\\' Kitchen",
+        "name": "Witches' Kitchen",
         "terrain": {
           "clear": true
         }

--- a/docs/refs/starting_units.json
+++ b/docs/refs/starting_units.json
@@ -10,6 +10,13 @@
         "abilities": ["Mountaineer"]
       },
       {
+        "name": "Ghem Ambassador",
+        "count": 1,
+        "start_hex": [32, 9],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Rosengg Unit",
         "count": 3,
         "start_hex": [32, 9],
@@ -43,6 +50,13 @@
         "abilities": ["Forestwalking"]
       },
       {
+        "name": "Neuth Ambassador",
+        "count": 1,
+        "start_hex": [4, 5],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Ider Bolis Unit",
         "count": 6,
         "start_hex": [4, 5],
@@ -62,6 +76,13 @@
         "abilities": ["Mountaineer", "Forestwalking"]
       },
       {
+        "name": "Zorn Ambassador",
+        "count": 1,
+        "start_hex": [23, 2],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "The Pits Unit",
         "count": 3,
         "start_hex": [23, 2],
@@ -70,59 +91,15 @@
       },
       {
         "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [21, 7],
+        "count": 8,
         "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [20, 6],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [21, 5],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [20, 4],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [18, 4],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [18, 7],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [18, 0],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
-      },
-      {
-        "name": "Nithmere Unit",
-        "count": 1,
-        "start_hex": [19, 1],
-        "movement_points": 6,
-        "abilities": ["Mountaineer", "Forestwalking"]
+        "abilities": ["Mountaineer", "Forestwalking"],
+        "deployment": {
+          "type": "scattered",
+          "rules": "One per mountain or pass hex within Zorn territory, no two adjacent. Player chooses valid deployment.",
+          "example_start_hexes": [[21, 7], [20, 6], [21, 5], [20, 4], [18, 4], [18, 7], [18, 0], [19, 1]],
+          "note": "The example deployment is one valid option; other configurations meeting the adjacency rules are permitted"
+        }
       }
     ]
   },
@@ -135,6 +112,13 @@
         "start_hex": [9, 17],
         "movement_points": 7,
         "abilities": []
+      },
+      {
+        "name": "Hothior Ambassador",
+        "count": 1,
+        "start_hex": [9, 17],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
       },
       {
         "name": "Port Lork Unit",
@@ -191,6 +175,13 @@
         "abilities": []
       },
       {
+        "name": "Immer Ambassador",
+        "count": 1,
+        "start_hex": [14, 6],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Altarr Unit",
         "count": 3,
         "start_hex": [14, 6],
@@ -236,6 +227,13 @@
         "start_hex": [4, 21],
         "movement_points": 7,
         "abilities": []
+      },
+      {
+        "name": "Mivior Ambassador",
+        "count": 1,
+        "start_hex": [4, 21],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
       },
       {
         "name": "Colist Unit",
@@ -306,6 +304,13 @@
         "abilities": []
       },
       {
+        "name": "Muetar Ambassador",
+        "count": 1,
+        "start_hex": [19, 11],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Basimar Unit",
         "count": 3,
         "start_hex": [24, 9],
@@ -360,6 +365,13 @@
         "abilities": []
       },
       {
+        "name": "Pon Ambassador",
+        "count": 1,
+        "start_hex": [28, 17],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Marzarbol Unit",
         "count": 3,
         "start_hex": [28, 17],
@@ -398,6 +410,13 @@
         "start_hex": [5, 27],
         "movement_points": 7,
         "abilities": []
+      },
+      {
+        "name": "Rombune Ambassador",
+        "count": 1,
+        "start_hex": [5, 27],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
       },
       {
         "name": "Golkus Unit",
@@ -468,6 +487,13 @@
         "abilities": []
       },
       {
+        "name": "Shucassam Ambassador",
+        "count": 1,
+        "start_hex": [24, 23],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "Adeese Unit",
         "count": 4,
         "start_hex": [24, 23],
@@ -522,6 +548,13 @@
         "abilities": ["Mountaineer", "Forestwalking"]
       },
       {
+        "name": "Trolls Ambassador",
+        "count": 1,
+        "start_hex": [6, 13],
+        "movement_points": "teleport",
+        "abilities": ["Diplomatic"]
+      },
+      {
         "name": "The Crag Unit",
         "count": 2,
         "start_hex": [27, 2],
@@ -536,14 +569,14 @@
         "abilities": ["Mountaineer", "Forestwalking"]
       },
       {
-        "name": "The Face Unit",
+        "name": "Stone Face Unit",
         "count": 2,
         "start_hex": [6, 13],
         "movement_points": 4,
         "abilities": ["Mountaineer", "Forestwalking"]
       },
       {
-        "name": "The Digs Unit",
+        "name": "The Gathering Unit",
         "count": 2,
         "start_hex": [33, 21],
         "movement_points": 4,


### PR DESCRIPTION
- Fix factions.json: Remove 15 trailing commas, correct Basimar coords (25,8)→(24,9), update Ghem army counts to 8, Zorn to 11
- Fix hexmap.json: Rename Troll locations (The Face→Stone Face, The Digs→The Gathering), fix escaped apostrophes, remove intrinsic from The Keep
- Update starting_units.json: Add ambassadors to all factions, fix Troll unit names, convert Nithmere to array with example deployment
- Enhance dr3_rules.json: Add cities vs castles distinction (section 31), standardize coast→seashore terminology, document Troll rules including monarch start location