### PR TITLE
Remove export date field from minified factions schema

### DIFF
--- a/docs/refs/schema_factions.json
+++ b/docs/refs/schema_factions.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "docs/refs/schema_factions.json",
-  "description": "Compact factions schema. Keys: v=version, d=exportDate, f=factions, n=name, r=raceId, c=color, coa=coatOfArms, p=position[col,row], a=armies, sf=seaFleet, cap=isCapital, msl=monarchStartLocation",
+  "description": "Compact factions schema. Keys: v=version, f=factions, n=name, r=raceId, c=color, coa=coatOfArms, p=position[col,row], a=armies, sf=seaFleet, cap=isCapital, msl=monarchStartLocation",
   "type": "object",
-  "required": ["v", "d", "f"],
+  "required": ["v", "f"],
   "properties": {
     "v": {"type": "string"},
-    "d": {"type": "string"},
     "f": {
       "type": "array",
       "items": {


### PR DESCRIPTION
The minified factions.min.json intentionally omits the export date
metadata, so the schema should not require it.