### PR TITLE
Add conformance suite chunks 3–5 (diplomacy, sieges, events, special rules)

### DIFF
--- a/docs/conformance/chunk_3_advanced_mechanics/12_diplomacy.json
+++ b/docs/conformance/chunk_3_advanced_mechanics/12_diplomacy.json
@@ -1,0 +1,409 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "12_diplomacy",
+  "tests": [
+    {
+      "id": "12.1.1_diplomacy_only_between",
+      "rule_ref": "12.1.1",
+      "description": "Diplomacy only occurs between player monarchs and non-player monarchs/mercenaries/barbarians",
+      "input": {
+        "initiator_type": "player_monarch",
+        "target_type": "non_player_monarch"
+      },
+      "expected": {
+        "diplomacy_allowed": true
+      }
+    },
+    {
+      "id": "12.1.2_player_alliances_not_binding",
+      "rule_ref": "12.1.2",
+      "description": "Player monarch alliances are not binding; all player monarchs are enemies",
+      "input": {
+        "player_a_allied_with_player_b": true
+      },
+      "expected": {
+        "treat_as_enemies": true
+      }
+    },
+    {
+      "id": "12.1.3_ambassador_death_recovery_turns",
+      "rule_ref": "12.1.3",
+      "description": "Ambassador death removes diplomacy for the next two player turns",
+      "input": {
+        "ambassador_death_turn": 3
+      },
+      "expected": {
+        "turns_unavailable": 2
+      }
+    },
+    {
+      "id": "12.1.4_ambassador_teleport_movement",
+      "rule_ref": "12.1.4",
+      "description": "Ambassador teleports to function location then returns to royal castle",
+      "input": {
+        "origin": "royal_castle",
+        "function_location": "neutral_monarch_hex"
+      },
+      "expected": {
+        "teleport_allowed": true,
+        "returns_to_royal_castle": true
+      }
+    },
+    {
+      "id": "12.1.5_ambassador_return_blocked",
+      "rule_ref": "12.1.5",
+      "description": "If royal castle is enemy-occupied or besieged, ambassador returns to player monarch or off map",
+      "input": {
+        "royal_castle_enemy_occupied": true
+      },
+      "expected": {
+        "return_location": "player_monarch_hex_or_off_map"
+      }
+    },
+    {
+      "id": "12.2.1_threshold_comparison",
+      "rule_ref": "12.2.1",
+      "description": "Diplomatic success requires modified roll >= target number",
+      "input": {
+        "modified_roll": 6,
+        "target_number": 6
+      },
+      "expected": {
+        "success": true
+      }
+    },
+    {
+      "id": "12.2.2_card_played_before_roll",
+      "rule_ref": "12.2.2",
+      "description": "Diplomacy card is played before the die roll and modifier applied after",
+      "input": {
+        "card_played": true,
+        "die_roll": 4
+      },
+      "expected": {
+        "card_play_timing": "before_roll",
+        "modifier_application": "after_roll"
+      }
+    },
+    {
+      "id": "12.2.3_modified_result_formula",
+      "rule_ref": "12.2.3",
+      "description": "Modified result adds card and personality modifiers, subtracts diplomatic penalty",
+      "input": {
+        "die_roll": 3,
+        "diplomacy_card_modifier": 2,
+        "personality_modifier": 1,
+        "diplomatic_penalty": 1
+      },
+      "expected": {
+        "modified_roll": 5
+      }
+    },
+    {
+      "id": "12.2.4_automatic_success",
+      "rule_ref": "12.2.4",
+      "description": "If modifiers guarantee success regardless of roll, success is automatic",
+      "input": {
+        "minimum_modified_total": 7,
+        "target_number": 6
+      },
+      "expected": {
+        "automatic_success": true
+      }
+    },
+    {
+      "id": "12.3.1_activate_neutral_threshold",
+      "rule_ref": "12.3.1",
+      "description": "Activation of neutral monarch requires modified roll >= 6",
+      "input": {
+        "die_roll": 4,
+        "diplomacy_card_modifier": 2,
+        "personality_modifier": 0,
+        "diplomatic_penalty": 0
+      },
+      "expected": {
+        "modified_roll": 6,
+        "success": true
+      }
+    },
+    {
+      "id": "12.3.1_activate_neutral_effects",
+      "rule_ref": "12.3.1",
+      "description": "Successful activation allies monarch, places forces, and delays movement",
+      "input": {
+        "activation_success": true
+      },
+      "expected": {
+        "monarch_allied": true,
+        "forces_placed": true,
+        "units_active_next_turn": true
+      }
+    },
+    {
+      "id": "12.3.2_deactivate_threshold",
+      "rule_ref": "12.3.2",
+      "description": "Deactivation of enemy-allied monarch requires modified roll >= 7",
+      "input": {
+        "die_roll": 4,
+        "diplomacy_card_modifier": 2,
+        "personality_modifier": 0,
+        "diplomatic_penalty": 0
+      },
+      "expected": {
+        "modified_roll": 6,
+        "success": false
+      }
+    },
+    {
+      "id": "12.3.2_deactivate_effects",
+      "rule_ref": "12.3.2",
+      "description": "Successful deactivation removes forces after combat and returns cards",
+      "input": {
+        "deactivation_success": true
+      },
+      "expected": {
+        "forces_removed_after_combat": true,
+        "cards_returned": true
+      }
+    },
+    {
+      "id": "12.3.3_assassination_limit_once",
+      "rule_ref": "12.3.3",
+      "description": "Assassination attempt is limited to once per game per player",
+      "input": {
+        "previous_assassination_attempts": 1
+      },
+      "expected": {
+        "action_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "12.3.3_assassination_higher_roll_kills",
+      "rule_ref": "12.3.3",
+      "description": "Assassination succeeds when the initiator rolls higher",
+      "input": {
+        "initiator_roll": 5,
+        "target_roll": 2
+      },
+      "expected": {
+        "target_killed": true
+      }
+    },
+    {
+      "id": "12.3.4_duel_limit_once",
+      "rule_ref": "12.3.4",
+      "description": "Ambassador duels are limited to once per pair of ambassadors",
+      "input": {
+        "previous_duel_between_ambassadors": true
+      },
+      "expected": {
+        "duel_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "12.3.4_duel_tie_kills_both",
+      "rule_ref": "12.3.4",
+      "description": "Ambassador duel ties kill both ambassadors",
+      "input": {
+        "ambassador_a_roll": 4,
+        "ambassador_b_roll": 4
+      },
+      "expected": {
+        "both_ambassadors_die": true
+      }
+    },
+    {
+      "id": "12.4.1_ambassador_death_removal",
+      "rule_ref": "12.4.1",
+      "description": "Ambassador death removes the ambassador for the next two player turns",
+      "input": {
+        "turns_since_death": 1
+      },
+      "expected": {
+        "ambassador_available": false
+      }
+    },
+    {
+      "id": "12.4.3_no_diplomacy_during_death",
+      "rule_ref": "12.4.3",
+      "description": "Players may conduct no diplomacy while ambassador is dead",
+      "input": {
+        "ambassador_dead": true
+      },
+      "expected": {
+        "diplomacy_allowed": false
+      }
+    },
+    {
+      "id": "12.4.4_ambassador_recovery_turn",
+      "rule_ref": "12.4.4",
+      "description": "Successor ambassador becomes available on the third turn after death",
+      "input": {
+        "turns_since_death": 3
+      },
+      "expected": {
+        "ambassador_available": true
+      }
+    },
+    {
+      "id": "12.4.5_penalties_inherited",
+      "rule_ref": "12.4.5",
+      "description": "Diplomatic penalties are inherited by successor ambassadors",
+      "input": {
+        "existing_penalty": 1
+      },
+      "expected": {
+        "penalty_inherited": true
+      }
+    },
+    {
+      "id": "12.4.6_continue_card_draw",
+      "rule_ref": "12.4.6",
+      "description": "Diplomacy card draw continues while ambassador is dead",
+      "input": {
+        "ambassador_dead": true
+      },
+      "expected": {
+        "cards_drawn": true
+      }
+    },
+    {
+      "id": "12.5.1_banishment_triggering_cards",
+      "rule_ref": "12.5.1",
+      "description": "Banishment can be triggered by specific diplomacy cards",
+      "input": {
+        "card_name": "Black Magic"
+      },
+      "expected": {
+        "banishment_possible": true
+      }
+    },
+    {
+      "id": "12.5.2_banishment_on_failed_roll",
+      "rule_ref": "12.5.2",
+      "description": "Banishment occurs when the diplomatic die roll fails",
+      "input": {
+        "diplomatic_attempt_failed": true
+      },
+      "expected": {
+        "banishment_triggered": true
+      }
+    },
+    {
+      "id": "12.5.3_banishment_duration_formula",
+      "rule_ref": "12.5.3",
+      "description": "Banishment duration equals card modifier plus one turn",
+      "input": {
+        "card_modifier": 2
+      },
+      "expected": {
+        "banishment_duration_turns": 3
+      }
+    },
+    {
+      "id": "12.5.4_banishment_effect",
+      "rule_ref": "12.5.4",
+      "description": "Banishment blocks further diplomatic functions with the offended kingdom",
+      "input": {
+        "banishment_active": true
+      },
+      "expected": {
+        "diplomacy_blocked": true
+      }
+    },
+    {
+      "id": "12.5.5_multiple_banishments_add",
+      "rule_ref": "12.5.5",
+      "description": "Multiple banishments add their durations together",
+      "input": {
+        "banishment_terms": [2, 3]
+      },
+      "expected": {
+        "total_banishment_duration": 5
+      }
+    },
+    {
+      "id": "12.5.6_card_discard_before_result",
+      "rule_ref": "12.5.6",
+      "description": "Diplomacy cards are discarded before knowing the die roll result",
+      "input": {
+        "card_played": true,
+        "result_known": false
+      },
+      "expected": {
+        "card_discarded": true
+      }
+    },
+    {
+      "id": "12.6.1_penalty_trigger_border_violation",
+      "rule_ref": "12.6.1",
+      "description": "Crossing into a neutral kingdom triggers a diplomatic penalty",
+      "input": {
+        "border_violation": true,
+        "violated_kingdom_status": "neutral"
+      },
+      "expected": {
+        "diplomatic_penalty_applied": true
+      }
+    },
+    {
+      "id": "12.6.2_penalty_effect_minus_one",
+      "rule_ref": "12.6.2",
+      "description": "Diplomatic penalty applies -1 to future rolls in violated kingdom",
+      "input": {
+        "diplomatic_penalty": 1
+      },
+      "expected": {
+        "roll_modifier": -1
+      }
+    },
+    {
+      "id": "12.6.3_penalty_exceptions",
+      "rule_ref": "12.6.3",
+      "description": "Allied or enemy-allied kingdoms do not incur diplomatic penalties",
+      "input": {
+        "violated_kingdom_status": "allied"
+      },
+      "expected": {
+        "diplomatic_penalty_applied": false
+      }
+    },
+    {
+      "id": "12.6.4_penalty_not_cumulative",
+      "rule_ref": "12.6.4",
+      "description": "Diplomatic penalties are not cumulative",
+      "input": {
+        "existing_penalty": 1,
+        "new_penalty_event": true
+      },
+      "expected": {
+        "penalty_value": 1
+      }
+    },
+    {
+      "id": "12.6.5_deactivation_grace_period",
+      "rule_ref": "12.6.5",
+      "description": "Deactivation grants one movement phase to leave before penalty applies",
+      "input": {
+        "movement_phases_elapsed": 0,
+        "units_still_present": true
+      },
+      "expected": {
+        "diplomatic_penalty_applied": false
+      }
+    },
+    {
+      "id": "12.6.6_voluntary_elimination_avoids_penalty",
+      "rule_ref": "12.6.6",
+      "description": "Units may be voluntarily eliminated to avoid diplomatic penalty",
+      "input": {
+        "units_eliminated_voluntarily": true
+      },
+      "expected": {
+        "diplomatic_penalty_applied": false
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_3_advanced_mechanics/13_diplomacy_cards.json
+++ b/docs/conformance/chunk_3_advanced_mechanics/13_diplomacy_cards.json
@@ -1,0 +1,99 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "13_diplomacy_cards",
+  "tests": [
+    {
+      "id": "13.1_total_cards",
+      "rule_ref": "13.1",
+      "description": "Diplomacy deck contains 45 cards",
+      "input": {
+        "deck_type": "diplomacy"
+      },
+      "expected": {
+        "card_total": 45
+      }
+    },
+    {
+      "id": "13.2_basic_game_cards",
+      "rule_ref": "13.2",
+      "description": "Basic game uses 32 diplomacy cards",
+      "input": {
+        "game_mode": "basic"
+      },
+      "expected": {
+        "card_total": 32
+      }
+    },
+    {
+      "id": "13.3.1_diplomatic_ploys_bonus",
+      "rule_ref": "13.3.1",
+      "description": "Diplomatic ploys provide bonuses to the diplomacy die roll",
+      "input": {
+        "card_type": "diplomatic_ploy",
+        "card_modifier": 2
+      },
+      "expected": {
+        "modifier_applies": true
+      }
+    },
+    {
+      "id": "13.3.2_special_mercenary_count",
+      "rule_ref": "13.3.2",
+      "description": "Special mercenary diplomacy cards include 13 units in advanced game",
+      "input": {
+        "game_mode": "advanced"
+      },
+      "expected": {
+        "special_mercenary_cards": 13
+      }
+    },
+    {
+      "id": "13.4_cards_accumulate",
+      "rule_ref": "13.4",
+      "description": "Diplomacy cards may be accumulated",
+      "input": {
+        "cards_in_hand": 3,
+        "cards_drawn": 2
+      },
+      "expected": {
+        "new_hand_size": 5
+      }
+    },
+    {
+      "id": "13.5_cards_not_tradable",
+      "rule_ref": "13.5",
+      "description": "Diplomacy cards may not be traded or exchanged",
+      "input": {
+        "trade_attempt": true
+      },
+      "expected": {
+        "trade_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "13.6_reshuffle_when_exhausted",
+      "rule_ref": "13.6",
+      "description": "Discard pile is shuffled when the diplomacy deck is exhausted",
+      "input": {
+        "deck_empty": true,
+        "discard_pile_count": 10
+      },
+      "expected": {
+        "reshuffle_required": true
+      }
+    },
+    {
+      "id": "13.7_discard_after_use",
+      "rule_ref": "13.7",
+      "description": "Diplomacy cards are discarded after use regardless of success",
+      "input": {
+        "card_played": true,
+        "diplomacy_success": false
+      },
+      "expected": {
+        "card_discarded": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_3_advanced_mechanics/14_personality_cards.json
+++ b/docs/conformance/chunk_3_advanced_mechanics/14_personality_cards.json
@@ -1,0 +1,51 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "14_personality_cards",
+  "tests": [
+    {
+      "id": "14.1_total_personality_cards",
+      "rule_ref": "14.1",
+      "description": "There are 20 personality cards",
+      "input": {
+        "deck_type": "personality"
+      },
+      "expected": {
+        "card_total": 20
+      }
+    },
+    {
+      "id": "14.2_assignment_one_per_monarch",
+      "rule_ref": "14.2",
+      "description": "One personality card is assigned face-down to each non-player monarch",
+      "input": {
+        "non_player_monarchs": 5
+      },
+      "expected": {
+        "cards_assigned": 5,
+        "face_down": true
+      }
+    },
+    {
+      "id": "14.3_reveal_on_ambassador_visit",
+      "rule_ref": "14.3",
+      "description": "Personality card is read aloud when ambassador visits the monarch",
+      "input": {
+        "ambassador_visits_monarch": true
+      },
+      "expected": {
+        "card_revealed": true
+      }
+    },
+    {
+      "id": "14.4_personality_effects_apply",
+      "rule_ref": "14.4",
+      "description": "Personality cards modify diplomacy, movement, or combat as specified",
+      "input": {
+        "personality_modifier": 1
+      },
+      "expected": {
+        "modifier_applies": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_3_advanced_mechanics/17_sieges.json
+++ b/docs/conformance/chunk_3_advanced_mechanics/17_sieges.json
@@ -1,0 +1,804 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "17_sieges",
+  "tests": [
+    {
+      "id": "17.1.1_castle_surrounded_required",
+      "rule_ref": "17.1.1",
+      "description": "Castle must be fully surrounded by besieging units or zones of siege",
+      "input": {
+        "castle_surrounded": false
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.1.2_no_outside_defenders",
+      "rule_ref": "17.1.2",
+      "description": "Siege cannot be declared while defending units remain outside the castle",
+      "input": {
+        "outside_defenders_present": true
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.1.3_sufficient_force",
+      "rule_ref": "17.1.3",
+      "description": "Besieging units must be at least defending units plus intrinsic defense",
+      "input": {
+        "besieging_units": 5,
+        "defending_units": 2,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "siege_allowed": false,
+        "required_minimum": 6
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.2_cooperation_rule_no_combined_strength",
+      "rule_ref": "17.2",
+      "description": "Different players may not combine strengths for a single siege",
+      "input": {
+        "besieging_players": ["player_a", "player_b"],
+        "castle_hex": [10, 10]
+      },
+      "expected": {
+        "combined_strength_allowed": false
+      }
+    },
+    {
+      "id": "17.3.1_zone_extends_adjacent",
+      "rule_ref": "17.3.1",
+      "description": "Zone of siege extends one hex beyond adjacent besieging unit",
+      "input": {
+        "castle_hex": [10, 10],
+        "besieging_unit_hex": [10, 11]
+      },
+      "expected": {
+        "zone_extension_hexes": [[10, 12]]
+      }
+    },
+    {
+      "id": "17.3.2_zone_all_sea_only",
+      "rule_ref": "17.3.2",
+      "description": "Fleet siege zones extend only to all-sea or seashore hexes",
+      "input": {
+        "unit_type": "fleet",
+        "adjacent_hex_type": "all_land"
+      },
+      "expected": {
+        "zone_of_siege_extends": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.3.3_zone_all_land_only",
+      "rule_ref": "17.3.3",
+      "description": "Land units extend siege zones only to all-land and seashore hexes",
+      "input": {
+        "unit_type": "land",
+        "adjacent_hex_type": "all_sea"
+      },
+      "expected": {
+        "zone_of_siege_extends": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.3.4_zone_not_negated_by_friendly_units",
+      "rule_ref": "17.3.4",
+      "description": "Friendly units do not negate an existing zone of siege",
+      "input": {
+        "zone_of_siege_active": true,
+        "friendly_units_present": true
+      },
+      "expected": {
+        "zone_of_siege_active": true
+      }
+    },
+    {
+      "id": "17.4.1_units_inside_tracked",
+      "rule_ref": "17.4.1",
+      "description": "Units inside a castle are tracked separately during a siege",
+      "input": {
+        "units_inside": ["u1", "u2"]
+      },
+      "expected": {
+        "inside_units_recorded": true
+      }
+    },
+    {
+      "id": "17.4.2_outside_units_must_be_eliminated",
+      "rule_ref": "17.4.2",
+      "description": "Outside defenders must be eliminated or forced to retreat before siege",
+      "input": {
+        "outside_defenders_present": true
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.4.3_outside_units_attacked_in_combat_phase",
+      "rule_ref": "17.4.3",
+      "description": "Outside defenders are attacked during the combat-resolution phase",
+      "input": {
+        "phase": "combat_resolution",
+        "outside_defenders_present": true
+      },
+      "expected": {
+        "outside_units_attackable": true
+      }
+    },
+    {
+      "id": "17.4.4_retreat_into_castle_before_combat",
+      "rule_ref": "17.4.4",
+      "description": "Defenders may retreat into castle before combat to join siege defense",
+      "input": {
+        "retreat_before_combat": true,
+        "destination": "inside_castle"
+      },
+      "expected": {
+        "retreat_allowed": true
+      }
+    },
+    {
+      "id": "17.4.5_leader_bonus_not_outside",
+      "rule_ref": "17.4.5",
+      "description": "Leaders inside the castle cannot apply bonuses to outside defenders",
+      "input": {
+        "leader_inside_castle": true,
+        "outside_defenders_present": true
+      },
+      "expected": {
+        "leader_bonus_applies": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.4.6_move_in_out_no_cost",
+      "rule_ref": "17.4.6",
+      "description": "Moving in or out of a castle hex during a siege costs no movement points",
+      "input": {
+        "movement_through_castle": true
+      },
+      "expected": {
+        "movement_cost": 0
+      }
+    },
+    {
+      "id": "17.4.7_move_only_during_movement_phase",
+      "rule_ref": "17.4.7",
+      "description": "Moving into or out of a castle is only allowed during movement or retreat",
+      "input": {
+        "phase": "combat",
+        "attempt_move_outside": true
+      },
+      "expected": {
+        "movement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.5.1_intrinsic_defense_from_hex",
+      "rule_ref": "17.5.1",
+      "description": "Intrinsic defense strength comes from the castle hex value",
+      "input": {
+        "castle_hex": [5, 5],
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "defense_strength": 4
+      }
+    },
+    {
+      "id": "17.5.2_intrinsic_defense_only_for_siege",
+      "rule_ref": "17.5.2",
+      "description": "Intrinsic defense is used only for siege resolution",
+      "input": {
+        "combat_type": "regular",
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "defense_applies": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.5.3_intact_castle_blocks_entry",
+      "rule_ref": "17.5.3",
+      "description": "Enemy units cannot enter an intact castle hex",
+      "input": {
+        "castle_plundered": false,
+        "enemy_unit_attempts_entry": true
+      },
+      "expected": {
+        "entry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.5.4_plundered_castle_no_defense",
+      "rule_ref": "17.5.4",
+      "description": "Plundered castles have no intrinsic defense strength",
+      "input": {
+        "castle_plundered": true,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "defense_strength": 0
+      }
+    },
+    {
+      "id": "17.6.1_siege_declared_when_conditions_met",
+      "rule_ref": "17.6.1",
+      "description": "Siege is declared immediately when all conditions are satisfied",
+      "input": {
+        "requirements_met": true
+      },
+      "expected": {
+        "siege_declared": true
+      }
+    },
+    {
+      "id": "17.6.2_any_player_may_declare",
+      "rule_ref": "17.6.2",
+      "description": "Any player may declare siege when conditions are met",
+      "input": {
+        "declaring_player": "player_b",
+        "besieging_forces_owner": "player_a"
+      },
+      "expected": {
+        "siege_declaration_allowed": true
+      }
+    },
+    {
+      "id": "17.6.3_retreat_before_combat_not_besieging",
+      "rule_ref": "17.6.3",
+      "description": "Units that retreated before combat do not count as besieging until next movement phase",
+      "input": {
+        "retreat_before_combat": true
+      },
+      "expected": {
+        "counts_as_besieging": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.7.1_reinforcements_blocked",
+      "rule_ref": "17.7.1",
+      "description": "Reinforcements cannot enter a besieged castle",
+      "input": {
+        "castle_besieged": true,
+        "attempt_entry": true
+      },
+      "expected": {
+        "entry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.7.2_must_attack_besiegers_first",
+      "rule_ref": "17.7.2",
+      "description": "Units leaving a siege must first attack all besieging units",
+      "input": {
+        "attempt_leave_siege": true,
+        "besiegers_remaining": true
+      },
+      "expected": {
+        "must_attack_besiegers": true
+      }
+    },
+    {
+      "id": "17.7.2_leave_siege_after_resolution",
+      "rule_ref": "17.7.2",
+      "description": "Leaving a siege occurs during the siege-resolution phase",
+      "input": {
+        "phase": "siege_resolution",
+        "attack_resolved": true
+      },
+      "expected": {
+        "may_exit_zone": true
+      }
+    },
+    {
+      "id": "17.7.3_attack_from_siege_combat_phase",
+      "rule_ref": "17.7.3",
+      "description": "Besieged units may attack during combat phase instead of siege resolution",
+      "input": {
+        "attack_from_siege": true,
+        "phase": "combat"
+      },
+      "expected": {
+        "attack_allowed": true
+      }
+    },
+    {
+      "id": "17.7.3_attack_from_siege_advance_limit",
+      "rule_ref": "17.7.3",
+      "description": "Attack from siege allows advance only one hex if all defenders eliminated",
+      "input": {
+        "attack_from_siege": true,
+        "defenders_eliminated": true
+      },
+      "expected": {
+        "advance_limit_hexes": 1
+      }
+    },
+    {
+      "id": "17.7.3_outside_forces_join",
+      "rule_ref": "17.7.3",
+      "description": "Outside friendly forces may join siege attack from outside",
+      "input": {
+        "outside_forces_present": true,
+        "attack_from_siege": true
+      },
+      "expected": {
+        "outside_forces_may_join": true
+      }
+    },
+    {
+      "id": "17.7.3_attack_from_siege_breaks_siege",
+      "rule_ref": "17.7.3",
+      "description": "Units that remain outside after attacking from siege break the siege",
+      "input": {
+        "attack_from_siege": true,
+        "attackers_remain_outside": true
+      },
+      "expected": {
+        "siege_broken": true
+      }
+    },
+    {
+      "id": "17.8.1_resolution_in_siege_phase",
+      "rule_ref": "17.8.1",
+      "description": "Siege resolution happens in the besieger's siege resolution phase",
+      "input": {
+        "phase": "siege_resolution"
+      },
+      "expected": {
+        "resolution_allowed": true
+      }
+    },
+    {
+      "id": "17.8.2_siege_roll_single_die",
+      "rule_ref": "17.8.2",
+      "description": "Siege resolution uses a single d6 roll",
+      "input": {
+        "siege_resolution": true
+      },
+      "expected": {
+        "die_type": "d6",
+        "dice_count": 1
+      }
+    },
+    {
+      "id": "17.8.3_siege_roll_one_to_five_no_effect",
+      "rule_ref": "17.8.3",
+      "description": "Siege continues on modified roll of 1-5",
+      "input": {
+        "siege_roll": 5,
+        "siege_modifier": 0
+      },
+      "expected": {
+        "modified_roll": 5,
+        "castle_taken": false,
+        "siege_continues": true
+      }
+    },
+    {
+      "id": "17.8.4_siege_roll_six_taken",
+      "rule_ref": "17.8.4",
+      "description": "Siege succeeds on modified roll of 6+",
+      "input": {
+        "siege_roll": 5,
+        "siege_modifier": 1
+      },
+      "expected": {
+        "modified_roll": 6,
+        "castle_taken": true,
+        "leaders_require_fate_roll": true
+      }
+    },
+    {
+      "id": "17.8.5_siege_attackers_no_move_after",
+      "rule_ref": "17.8.5",
+      "description": "Units making a siege attack cannot move or attack again",
+      "input": {
+        "siege_attack_made": true
+      },
+      "expected": {
+        "further_actions_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.9.1_siege_modifier_formula",
+      "rule_ref": "17.9.1",
+      "description": "Siege modifier uses (attacking / (defending + intrinsic)) - 1",
+      "input": {
+        "attacking_units": 10,
+        "defending_units": 4,
+        "intrinsic_defense": 2
+      },
+      "expected": {
+        "siege_modifier": 0
+      }
+    },
+    {
+      "id": "17.9.2_siege_modifier_drop_fraction",
+      "rule_ref": "17.9.2",
+      "description": "Siege modifier drops fractional results",
+      "input": {
+        "attacking_units": 15,
+        "defending_units": 4,
+        "intrinsic_defense": 3
+      },
+      "expected": {
+        "raw_ratio": 2.14,
+        "ratio_after_drop": 2
+      }
+    },
+    {
+      "id": "17.9.3_siege_modifier_applies_to_attacker",
+      "rule_ref": "17.9.3",
+      "description": "Siege modifier is added to the attacker's siege roll",
+      "input": {
+        "attacker_roll": 4,
+        "siege_modifier": 1
+      },
+      "expected": {
+        "modified_roll": 5
+      }
+    },
+    {
+      "id": "17.9.4_siege_modifier_example_one",
+      "rule_ref": "17.9.4",
+      "description": "15 attackers vs 4 defense + 3 inside yields +1 modifier",
+      "input": {
+        "attacking_units": 15,
+        "defending_units": 3,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "siege_modifier": 1
+      }
+    },
+    {
+      "id": "17.9.5_siege_modifier_example_two",
+      "rule_ref": "17.9.5",
+      "description": "15 attackers vs 4 defense + 4 inside yields +0 modifier",
+      "input": {
+        "attacking_units": 15,
+        "defending_units": 4,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "siege_modifier": 0
+      }
+    },
+    {
+      "id": "17.9.6_siege_modifier_example_three",
+      "rule_ref": "17.9.6",
+      "description": "15 attackers vs 4 defense + 1 inside yields +2 modifier",
+      "input": {
+        "attacking_units": 15,
+        "defending_units": 1,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "siege_modifier": 2
+      }
+    },
+    {
+      "id": "17.10.1_plundered_castle_nonexistent",
+      "rule_ref": "17.10.1",
+      "description": "Plundered castles are treated as nonexistent for siege/combat",
+      "input": {
+        "castle_plundered": true
+      },
+      "expected": {
+        "castle_counts_for_siege": false
+      }
+    },
+    {
+      "id": "17.10.2_plundered_castle_placement_hex",
+      "rule_ref": "17.10.2",
+      "description": "Plundered castles still function as placement hexes",
+      "input": {
+        "castle_plundered": true
+      },
+      "expected": {
+        "placement_allowed": true
+      }
+    },
+    {
+      "id": "17.10.3_plundered_royal_castle_diplomacy",
+      "rule_ref": "17.10.3",
+      "description": "Plundered royal castles may still serve diplomacy if not enemy occupied",
+      "input": {
+        "castle_plundered": true,
+        "enemy_occupied": false
+      },
+      "expected": {
+        "diplomacy_location_available": true
+      }
+    },
+    {
+      "id": "17.10.4_plundered_castle_makes_friendly",
+      "rule_ref": "17.10.4",
+      "description": "Occupation of plundered castle makes it friendly for mercenary deployment",
+      "input": {
+        "castle_plundered": true,
+        "occupied_by_player": "player_a"
+      },
+      "expected": {
+        "counts_as_friendly_for_mercenaries": true
+      }
+    },
+    {
+      "id": "17.10.5_plundered_castle_permanent",
+      "rule_ref": "17.10.5",
+      "description": "Plundered castle status is permanent",
+      "input": {
+        "castle_plundered": true,
+        "turns_elapsed": 3
+      },
+      "expected": {
+        "plundered_status_persists": true
+      }
+    },
+    {
+      "id": "17.11.1_fleets_participate_in_siege",
+      "rule_ref": "17.11.1",
+      "description": "Fleets may contribute to siege attack and defense",
+      "input": {
+        "fleet_present": true
+      },
+      "expected": {
+        "fleet_counts_in_siege": true
+      }
+    },
+    {
+      "id": "17.11.2_fleet_cannot_attack_all_land",
+      "rule_ref": "17.11.2",
+      "description": "Fleets cannot attack all-land hexes during sieges",
+      "input": {
+        "fleet_attacking_hex_type": "all_land"
+      },
+      "expected": {
+        "fleet_attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.11.3_port_siege_requires_fleet",
+      "rule_ref": "17.11.3",
+      "description": "Siege of port requires at least one besieging fleet",
+      "input": {
+        "castle_is_port": true,
+        "besieging_fleets": 0
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.11.4_port_siege_zone_coverage",
+      "rule_ref": "17.11.4",
+      "description": "All adjacent all-sea hexes must be covered to besiege a port",
+      "input": {
+        "adjacent_all_sea_hexes": 2,
+        "covered_all_sea_hexes": 1
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.11.5_seaborne_units_count_in_siege",
+      "rule_ref": "17.11.5",
+      "description": "Seaborne land units count in siege strength and fight only in siege combat",
+      "input": {
+        "seaborne_units": 2,
+        "siege_combat": true
+      },
+      "expected": {
+        "seaborne_units_count": true,
+        "regular_combat_allowed": false
+      }
+    },
+    {
+      "id": "17.12.1_relief_force_procedure",
+      "rule_ref": "17.12.1",
+      "description": "Relieving force moves adjacent, attacks besiegers, may advance into castle",
+      "input": {
+        "relief_force_adjacent": true,
+        "attack_besiegers": true,
+        "combat_won": true
+      },
+      "expected": {
+        "advance_into_castle_allowed": true
+      }
+    },
+    {
+      "id": "17.12.2_relief_force_two_hex_advance",
+      "rule_ref": "17.12.2",
+      "description": "Relief force may advance two hexes when castle is surrounded",
+      "input": {
+        "castle_surrounded": true,
+        "cleared_hex": [10, 9],
+        "castle_hex": [10, 10]
+      },
+      "expected": {
+        "advance_allowed_hexes": 2
+      }
+    },
+    {
+      "id": "17.12.3_relief_force_post_options",
+      "rule_ref": "17.12.3",
+      "description": "Relieving forces may remain outside or enter the castle",
+      "input": {
+        "relief_force_broke_siege": true
+      },
+      "expected": {
+        "post_relief_options": ["remain_outside", "enter_castle"]
+      }
+    },
+    {
+      "id": "17.13.1_forced_peace_trigger",
+      "rule_ref": "17.13.1",
+      "description": "Forced peace triggers when allied royal castle is plundered and occupied",
+      "input": {
+        "royal_castle_plundered": true,
+        "occupied_by_enemy": true
+      },
+      "expected": {
+        "forced_peace_roll_required": true
+      }
+    },
+    {
+      "id": "17.13.2_forced_peace_roll_timing",
+      "rule_ref": "17.13.2",
+      "description": "Forced peace roll occurs during occupying player's diplomacy phase",
+      "input": {
+        "phase": "diplomacy",
+        "occupying_player": true
+      },
+      "expected": {
+        "forced_peace_roll_allowed": true
+      }
+    },
+    {
+      "id": "17.13.3_forced_peace_special_roll",
+      "rule_ref": "17.13.3",
+      "description": "Forced peace uses a special die roll separate from diplomacy cards",
+      "input": {
+        "forced_peace_roll": 5,
+        "diplomacy_card_modifier": 2
+      },
+      "expected": {
+        "card_modifiers_apply": false
+      }
+    },
+    {
+      "id": "17.13.5_forced_peace_success_rolls",
+      "rule_ref": "17.13.5",
+      "description": "Forced peace succeeds on rolls of 5 or 6",
+      "input": {
+        "forced_peace_roll": 5
+      },
+      "expected": {
+        "forced_peace_success": true
+      }
+    },
+    {
+      "id": "17.13.6_forced_peace_contested_modifier",
+      "rule_ref": "17.13.6",
+      "description": "If contested, only a 6 succeeds for forced peace",
+      "input": {
+        "forced_peace_roll": 5,
+        "contested_last_turn": true
+      },
+      "expected": {
+        "forced_peace_success": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.13.7_forced_peace_no_modifiers",
+      "rule_ref": "17.13.7",
+      "description": "Diplomacy cards and penalties do not apply to forced peace",
+      "input": {
+        "forced_peace_roll": 6,
+        "diplomacy_card_modifier": 2,
+        "diplomatic_penalty": 1
+      },
+      "expected": {
+        "modified_roll": 6
+      }
+    },
+    {
+      "id": "17.13.8_forced_peace_alternative_normal_diplomacy",
+      "rule_ref": "17.13.8",
+      "description": "Normal diplomacy may be used instead of forced peace roll",
+      "input": {
+        "choose_normal_diplomacy": true
+      },
+      "expected": {
+        "forced_peace_roll_required": false
+      }
+    },
+    {
+      "id": "17.13.9_forced_peace_effects",
+      "rule_ref": "17.13.9",
+      "description": "Forced peace removes units and returns cards to neutral pool",
+      "input": {
+        "forced_peace_success": true
+      },
+      "expected": {
+        "units_removed": true,
+        "cards_returned": true
+      }
+    },
+    {
+      "id": "17.13.10_forced_peace_violation_effect",
+      "rule_ref": "17.13.10",
+      "description": "Violating forced peace ends it and applies diplomatic penalty",
+      "input": {
+        "forced_peace_active": true,
+        "border_violation": true
+      },
+      "expected": {
+        "forced_peace_ends": true,
+        "diplomatic_penalty_applied": true
+      }
+    },
+    {
+      "id": "17.13.11_forced_peace_unit_status",
+      "rule_ref": "17.13.11",
+      "description": "Only regulars alive at deactivation set up if reactivated",
+      "input": {
+        "regulars_alive_at_deactivation": 2,
+        "regulars_eliminated": 1
+      },
+      "expected": {
+        "regulars_available_on_reactivation": 2
+      }
+    },
+    {
+      "id": "17.13.12_plundered_castles_remain",
+      "rule_ref": "17.13.12",
+      "description": "Plundered castles remain plundered after forced peace",
+      "input": {
+        "forced_peace_success": true,
+        "plundered_castle": true
+      },
+      "expected": {
+        "plundered_status_persists": true
+      }
+    },
+    {
+      "id": "17.13.13_player_monarchs_not_subject",
+      "rule_ref": "17.13.13",
+      "description": "Player monarchs are never subject to forced peace",
+      "input": {
+        "monarch_type": "player",
+        "forced_peace_trigger": true
+      },
+      "expected": {
+        "forced_peace_applicable": false
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_4_events_outcomes/08_random_events.json
+++ b/docs/conformance/chunk_4_events_outcomes/08_random_events.json
@@ -1,0 +1,258 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "08_random_events",
+  "tests": [
+    {
+      "id": "8.1_random_event_roll_two_dice",
+      "rule_ref": "8.1",
+      "description": "Random events are resolved with a 2d6 roll",
+      "input": {
+        "event_triggered": true
+      },
+      "expected": {
+        "dice_count": 2,
+        "die_type": "d6"
+      }
+    },
+    {
+      "id": "8.2.1_roll_two_untimely_death",
+      "rule_ref": "8.2.1",
+      "description": "Roll of 2 results in Untimely Death",
+      "input": {
+        "event_roll": 2
+      },
+      "expected": {
+        "event": "untimely_death"
+      }
+    },
+    {
+      "id": "8.2.2_roll_three_storms",
+      "rule_ref": "8.2.2",
+      "description": "Roll of 3 results in Storms",
+      "input": {
+        "event_roll": 3
+      },
+      "expected": {
+        "event": "storms",
+        "fleet_losses": 1
+      }
+    },
+    {
+      "id": "8.2.3_roll_four_mutiny",
+      "rule_ref": "8.2.3",
+      "description": "Roll of 4 results in Mutiny",
+      "input": {
+        "event_roll": 4
+      },
+      "expected": {
+        "event": "mutiny",
+        "unit_losses": 1
+      }
+    },
+    {
+      "id": "8.2.4_roll_five_bad_omens",
+      "rule_ref": "8.2.4",
+      "description": "Roll of 5 results in Bad Omens",
+      "input": {
+        "event_roll": 5
+      },
+      "expected": {
+        "event": "bad_omens",
+        "kingdom_fight_restricted": true
+      }
+    },
+    {
+      "id": "8.2.5_roll_six_replacements",
+      "rule_ref": "8.2.5",
+      "description": "Roll of 6 results in Replacements",
+      "input": {
+        "event_roll": 6
+      },
+      "expected": {
+        "event": "replacements",
+        "regulars_replaced": 2
+      }
+    },
+    {
+      "id": "8.2.6_roll_seven_no_event",
+      "rule_ref": "8.2.6",
+      "description": "Roll of 7 results in No Event",
+      "input": {
+        "event_roll": 7
+      },
+      "expected": {
+        "event": "no_event"
+      }
+    },
+    {
+      "id": "8.2.7_roll_eight_reinforcements",
+      "rule_ref": "8.2.7",
+      "description": "Roll of 8 results in Reinforcements",
+      "input": {
+        "event_roll": 8
+      },
+      "expected": {
+        "event": "reinforcements",
+        "mercenary_units_gained": 2
+      }
+    },
+    {
+      "id": "8.2.8_roll_nine_plague",
+      "rule_ref": "8.2.8",
+      "description": "Roll of 9 results in Plague",
+      "input": {
+        "event_roll": 9
+      },
+      "expected": {
+        "event": "plague",
+        "unit_losses": 1
+      }
+    },
+    {
+      "id": "8.2.9_roll_ten_replacement",
+      "rule_ref": "8.2.9",
+      "description": "Roll of 10 results in Replacement",
+      "input": {
+        "event_roll": 10
+      },
+      "expected": {
+        "event": "replacement",
+        "units_gained": 1
+      }
+    },
+    {
+      "id": "8.2.10_roll_eleven_desertion",
+      "rule_ref": "8.2.10",
+      "description": "Roll of 11 results in Desertion",
+      "input": {
+        "event_roll": 11
+      },
+      "expected": {
+        "event": "desertion",
+        "mercenary_losses": 1
+      }
+    },
+    {
+      "id": "8.2.11_roll_twelve_help_from_afar",
+      "rule_ref": "8.2.11",
+      "description": "Roll of 12 results in Help From Afar",
+      "input": {
+        "event_roll": 12
+      },
+      "expected": {
+        "event": "help_from_afar",
+        "neutral_ally_activated": true
+      }
+    },
+    {
+      "id": "8.3.1_event_applies_only_to_roller",
+      "rule_ref": "8.3.1",
+      "description": "Random event effects apply only to the rolling player",
+      "input": {
+        "rolling_player": "player_a",
+        "other_player": "player_b"
+      },
+      "expected": {
+        "effect_targets": ["player_a"]
+      }
+    },
+    {
+      "id": "8.3.2_regular_placement_at_counter",
+      "rule_ref": "8.3.2",
+      "description": "Regular replacements are placed at the location named on the counter",
+      "input": {
+        "replacement_unit": "regular",
+        "counter_location": [12, 5]
+      },
+      "expected": {
+        "placement_hex": [12, 5]
+      }
+    },
+    {
+      "id": "8.3.3_blocked_placement_fails",
+      "rule_ref": "8.3.3",
+      "description": "Replacements cannot enter if the placement hex is enemy-occupied or besieged",
+      "input": {
+        "placement_hex_enemy_occupied": true
+      },
+      "expected": {
+        "placement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "8.3.4_mercenary_placement_friendly",
+      "rule_ref": "8.3.4",
+      "description": "Mercenary reinforcements may be placed at any friendly castle or port",
+      "input": {
+        "available_friendly_locations": ["castle", "port"]
+      },
+      "expected": {
+        "placement_options": ["castle", "port"]
+      }
+    },
+    {
+      "id": "8.3.5_fleet_reinforcement_requires_port",
+      "rule_ref": "8.3.5",
+      "description": "Fleet reinforcements require at least one friendly port",
+      "input": {
+        "friendly_ports": 0,
+        "reinforcement_type": "fleet"
+      },
+      "expected": {
+        "reinforcement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "8.3.6_regular_limit_respected",
+      "rule_ref": "8.3.6",
+      "description": "Regular replacements cannot exceed identity card limit",
+      "input": {
+        "current_regulars": 4,
+        "identity_card_limit": 4,
+        "replacements_requested": 1
+      },
+      "expected": {
+        "replacement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "8.3.7_immediate_action_for_replacements",
+      "rule_ref": "8.3.7",
+      "description": "Replacements and reinforcements may move and fight immediately",
+      "input": {
+        "unit_replaced_this_turn": true
+      },
+      "expected": {
+        "may_move": true,
+        "may_fight": true
+      }
+    },
+    {
+      "id": "8.3.8_impossible_event_no_event",
+      "rule_ref": "8.3.8",
+      "description": "If an event is impossible, treat it as No Event",
+      "input": {
+        "event": "reinforcements",
+        "conditions_met": false
+      },
+      "expected": {
+        "event": "no_event"
+      }
+    },
+    {
+      "id": "8.3.9_no_transfer_between_players",
+      "rule_ref": "8.3.9",
+      "description": "Replacements and reinforcements may not be transferred between players",
+      "input": {
+        "transfer_attempt": true
+      },
+      "expected": {
+        "transfer_allowed": false
+      },
+      "tags": ["negative"]
+    }
+  ]
+}

--- a/docs/conformance/chunk_4_events_outcomes/28_death_and_capture.json
+++ b/docs/conformance/chunk_4_events_outcomes/28_death_and_capture.json
@@ -1,0 +1,343 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "28_death_and_capture",
+  "tests": [
+    {
+      "id": "28.1.1_non_player_death_confusion",
+      "rule_ref": "28.1.1",
+      "description": "Non-player monarch death places kingdom in confusion",
+      "input": {
+        "non_player_monarch_died": true
+      },
+      "expected": {
+        "kingdom_status": "confusion"
+      }
+    },
+    {
+      "id": "28.1.2_confusion_duration_roll",
+      "rule_ref": "28.1.2",
+      "description": "Confusion duration is determined by 1d6",
+      "input": {
+        "confusion_roll": 4
+      },
+      "expected": {
+        "confusion_turns": 4
+      }
+    },
+    {
+      "id": "28.1.3_confusion_restricts_regulars",
+      "rule_ref": "28.1.3",
+      "description": "During confusion, regulars defend but cannot move, siege, or initiate combat",
+      "input": {
+        "kingdom_status": "confusion"
+      },
+      "expected": {
+        "can_move": false,
+        "can_siege": false,
+        "can_attack": false,
+        "can_defend": true
+      }
+    },
+    {
+      "id": "28.1.4_confusion_end_new_personality",
+      "rule_ref": "28.1.4",
+      "description": "At end of confusion, draw new personality card for the monarch",
+      "input": {
+        "confusion_ended": true
+      },
+      "expected": {
+        "new_personality_drawn": true
+      }
+    },
+    {
+      "id": "28.1.5_border_violation_ends_confusion",
+      "rule_ref": "28.1.5",
+      "description": "Border violation during confusion triggers penalty and immediate availability",
+      "input": {
+        "kingdom_status": "confusion",
+        "border_violation": true
+      },
+      "expected": {
+        "diplomatic_penalty_applied": true,
+        "kingdom_available": true
+      }
+    },
+    {
+      "id": "28.1.6_eliminated_regulars_remain",
+      "rule_ref": "28.1.6",
+      "description": "Eliminated regulars remain eliminated during confusion",
+      "input": {
+        "eliminated_regulars": 2
+      },
+      "expected": {
+        "eliminated_regulars_remaining": 2
+      }
+    },
+    {
+      "id": "28.2.1_player_monarch_death_eliminates_player",
+      "rule_ref": "28.2.1",
+      "description": "Player monarch death or capture removes the player from the game",
+      "input": {
+        "player_monarch_status": "captured"
+      },
+      "expected": {
+        "player_eliminated": true
+      }
+    },
+    {
+      "id": "28.2.2_allies_deactivate",
+      "rule_ref": "28.2.2",
+      "description": "All allied kingdoms of an eliminated player are deactivated",
+      "input": {
+        "player_eliminated": true,
+        "allied_kingdoms": ["neuth", "zorn"]
+      },
+      "expected": {
+        "allies_deactivated": true
+      }
+    },
+    {
+      "id": "28.2.3_player_kingdom_confusion",
+      "rule_ref": "28.2.3",
+      "description": "Eliminated player's kingdom enters confusion",
+      "input": {
+        "player_eliminated": true
+      },
+      "expected": {
+        "kingdom_status": "confusion"
+      }
+    },
+    {
+      "id": "28.2.4_after_confusion_new_monarch",
+      "rule_ref": "28.2.4",
+      "description": "After confusion, a new non-player monarch is available for diplomacy",
+      "input": {
+        "confusion_ended": true
+      },
+      "expected": {
+        "new_monarch_available": true
+      }
+    },
+    {
+      "id": "28.2.5_player_keeps_victory_points",
+      "rule_ref": "28.2.5",
+      "description": "Eliminated player keeps previously earned victory points",
+      "input": {
+        "player_eliminated": true,
+        "victory_points": 50
+      },
+      "expected": {
+        "victory_points_retained": 50
+      }
+    },
+    {
+      "id": "28.2.6_eliminated_player_can_win",
+      "rule_ref": "28.2.6",
+      "description": "Eliminated player can still win if they have the highest points",
+      "input": {
+        "player_eliminated": true,
+        "highest_points": true
+      },
+      "expected": {
+        "eligible_for_victory": true
+      }
+    },
+    {
+      "id": "28.2.7_reentry_requires_approval",
+      "rule_ref": "28.2.7",
+      "description": "Reentry requires all other players to approve",
+      "input": {
+        "reentry_requested": true,
+        "other_players_approve": false
+      },
+      "expected": {
+        "reentry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "28.3.1_prisoner_placed_nearest_castle",
+      "rule_ref": "28.3.1",
+      "description": "Captured non-player monarch is placed in nearest unbesieged castle controlled by captor",
+      "input": {
+        "captor_castle_hex": [10, 10],
+        "castle_besieged": false
+      },
+      "expected": {
+        "prison_hex": [10, 10]
+      }
+    },
+    {
+      "id": "28.3.2_no_castle_options",
+      "rule_ref": "28.3.2",
+      "description": "If no castle is available, captor may execute or set free",
+      "input": {
+        "available_castles": 0
+      },
+      "expected": {
+        "options": ["execute", "release"]
+      }
+    },
+    {
+      "id": "28.3.3_capture_awards_points",
+      "rule_ref": "28.3.3",
+      "description": "Capture of non-player monarch awards victory points",
+      "input": {
+        "capture_occurred": true
+      },
+      "expected": {
+        "victory_points_awarded": true
+      }
+    },
+    {
+      "id": "28.3.4_prisoner_cannot_act",
+      "rule_ref": "28.3.4",
+      "description": "Prisoners cannot take offensive or defensive actions",
+      "input": {
+        "prisoner_status": "captured"
+      },
+      "expected": {
+        "may_attack": false,
+        "may_defend": false
+      }
+    },
+    {
+      "id": "28.3.5_release_conditions",
+      "rule_ref": "28.3.5",
+      "description": "Prisoner is released if prison castle is seized by allies or captor deactivates",
+      "input": {
+        "prison_castle_sieged_by_allies": true
+      },
+      "expected": {
+        "release_triggered": true
+      }
+    },
+    {
+      "id": "28.3.6_release_placement",
+      "rule_ref": "28.3.6",
+      "description": "Released monarch goes to nearest unplundered friendly castle or unit",
+      "input": {
+        "friendly_castle_hex": [9, 9]
+      },
+      "expected": {
+        "release_hex": [9, 9]
+      }
+    },
+    {
+      "id": "28.4.1_execute_prisoner_timing",
+      "rule_ref": "28.4.1",
+      "description": "Prisoners may be executed immediately or during a later diplomacy phase",
+      "input": {
+        "execution_phase": "diplomacy"
+      },
+      "expected": {
+        "execution_allowed": true
+      }
+    },
+    {
+      "id": "28.4.2_execute_prisoner_no_points",
+      "rule_ref": "28.4.2",
+      "description": "Execution does not grant additional victory points",
+      "input": {
+        "execution_occurred": true
+      },
+      "expected": {
+        "victory_points_awarded": false
+      }
+    },
+    {
+      "id": "28.4.3_execute_prisoner_penalty",
+      "rule_ref": "28.4.3",
+      "description": "Executing a prisoner imposes a permanent diplomatic penalty",
+      "input": {
+        "execution_occurred": true
+      },
+      "expected": {
+        "diplomatic_penalty_permanent": true
+      }
+    },
+    {
+      "id": "28.5.1_forced_peace_timing",
+      "rule_ref": "28.5.1",
+      "description": "Forced peace rolls occur during the jailer's diplomacy phase",
+      "input": {
+        "jailer_diplomacy_phase": true
+      },
+      "expected": {
+        "forced_peace_roll_allowed": true
+      }
+    },
+    {
+      "id": "28.5.3_forced_peace_success_rolls",
+      "rule_ref": "28.5.3",
+      "description": "Forced peace succeeds on rolls of 5 or 6",
+      "input": {
+        "forced_peace_roll": 6
+      },
+      "expected": {
+        "forced_peace_success": true
+      }
+    },
+    {
+      "id": "28.5.4_forced_peace_siege_modifier",
+      "rule_ref": "28.5.4",
+      "description": "If prison castle is besieged, only a 6 succeeds",
+      "input": {
+        "forced_peace_roll": 5,
+        "prison_castle_besieged": true
+      },
+      "expected": {
+        "forced_peace_success": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "28.5.5_forced_peace_no_modifiers",
+      "rule_ref": "28.5.5",
+      "description": "Diplomacy cards and penalties do not apply to forced peace",
+      "input": {
+        "forced_peace_roll": 5,
+        "diplomacy_card_modifier": 2,
+        "diplomatic_penalty": 1
+      },
+      "expected": {
+        "modified_roll": 5
+      }
+    },
+    {
+      "id": "28.5.6_forced_peace_alternative_diplomacy",
+      "rule_ref": "28.5.6",
+      "description": "Normal diplomacy can be attempted on a captive instead of forced peace",
+      "input": {
+        "choose_normal_diplomacy": true
+      },
+      "expected": {
+        "forced_peace_roll_required": false
+      }
+    },
+    {
+      "id": "28.5.7_forced_peace_only_jailer",
+      "rule_ref": "28.5.7",
+      "description": "Only the jailer may make forced peace rolls when royal castle is occupied",
+      "input": {
+        "royal_castle_occupied": true,
+        "acting_player": "non_jailer"
+      },
+      "expected": {
+        "forced_peace_roll_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "28.5.8_forced_peace_effects_reference",
+      "rule_ref": "28.5.8",
+      "description": "Forced peace on prisoner uses forced peace effects",
+      "input": {
+        "forced_peace_success": true
+      },
+      "expected": {
+        "apply_forced_peace_effects": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_4_events_outcomes/29_victory_conditions.json
+++ b/docs/conformance/chunk_4_events_outcomes/29_victory_conditions.json
@@ -1,0 +1,154 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "29_victory_conditions",
+  "tests": [
+    {
+      "id": "29.1_victory_points_determine_winner",
+      "rule_ref": "29.1",
+      "description": "Victory is determined by Victory Points",
+      "input": {
+        "victory_points": {"player_a": 40, "player_b": 30}
+      },
+      "expected": {
+        "winner": "player_a"
+      }
+    },
+    {
+      "id": "29.2_timed_victory_after_twenty_turns",
+      "rule_ref": "29.2",
+      "description": "After 20 turns, the highest victory points wins",
+      "input": {
+        "turn": 20,
+        "victory_points": {"player_a": 60, "player_b": 55}
+      },
+      "expected": {
+        "winner": "player_a"
+      }
+    },
+    {
+      "id": "29.3.1_plunder_castle_points",
+      "rule_ref": "29.3.1",
+      "description": "Plundering enemy castle awards 5 × intrinsic defense",
+      "input": {
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "victory_points": 20
+      }
+    },
+    {
+      "id": "29.3.2_plunder_royal_castle_points",
+      "rule_ref": "29.3.2",
+      "description": "Plundering enemy royal castle awards 10 × intrinsic defense",
+      "input": {
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "victory_points": 40
+      }
+    },
+    {
+      "id": "29.3.3_capture_enemy_allied_monarch",
+      "rule_ref": "29.3.3",
+      "description": "Capturing enemy allied monarch awards 30 points",
+      "input": {
+        "action": "capture_enemy_allied_monarch"
+      },
+      "expected": {
+        "victory_points": 30
+      }
+    },
+    {
+      "id": "29.3.4_kill_enemy_allied_monarch",
+      "rule_ref": "29.3.4",
+      "description": "Killing enemy allied monarch awards 40 points",
+      "input": {
+        "action": "kill_enemy_allied_monarch"
+      },
+      "expected": {
+        "victory_points": 40
+      }
+    },
+    {
+      "id": "29.3.5_capture_or_kill_player_monarch",
+      "rule_ref": "29.3.5",
+      "description": "Capturing or killing enemy player monarch awards 70 points",
+      "input": {
+        "action": "capture_player_monarch"
+      },
+      "expected": {
+        "victory_points": 70
+      }
+    },
+    {
+      "id": "29.4.1_assassination_kill_no_points",
+      "rule_ref": "29.4.1",
+      "description": "Assassination kills grant no victory points",
+      "input": {
+        "action": "assassination_kill"
+      },
+      "expected": {
+        "victory_points": 0
+      }
+    },
+    {
+      "id": "29.4.2_execute_prisoner_no_points",
+      "rule_ref": "29.4.2",
+      "description": "Executing prisoners grants no additional victory points",
+      "input": {
+        "action": "execute_prisoner"
+      },
+      "expected": {
+        "victory_points": 0
+      }
+    },
+    {
+      "id": "29.4.3_plunder_once_per_castle",
+      "rule_ref": "29.4.3",
+      "description": "Castles may be plundered for points only once per game",
+      "input": {
+        "castle_plundered_before": true
+      },
+      "expected": {
+        "victory_points_awarded": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "29.4.4_plundered_status_permanent",
+      "rule_ref": "29.4.4",
+      "description": "Plundered status of a castle is permanent",
+      "input": {
+        "castle_plundered": true,
+        "turns_elapsed": 5
+      },
+      "expected": {
+        "plundered_status_persists": true
+      }
+    },
+    {
+      "id": "29.4.5_capture_escape_recapture_points",
+      "rule_ref": "29.4.5",
+      "description": "Points are awarded each time a monarch is captured",
+      "input": {
+        "captures": 2,
+        "points_per_capture": 30
+      },
+      "expected": {
+        "victory_points": 60
+      }
+    },
+    {
+      "id": "29.4.6_posthumous_victory",
+      "rule_ref": "29.4.6",
+      "description": "Eliminated player can win if they have the highest points",
+      "input": {
+        "player_eliminated": true,
+        "highest_points": true
+      },
+      "expected": {
+        "eligible_for_victory": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_5_special_rules/30_special_kingdom_rules.json
+++ b/docs/conformance/chunk_5_special_rules/30_special_kingdom_rules.json
@@ -1,0 +1,141 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "30_special_kingdom_rules",
+  "tests": [
+    {
+      "id": "30.1.1_troll_setup_locations",
+      "rule_ref": "30.1.1",
+      "description": "Trolls have four separate setup locations",
+      "input": {
+        "troll_setup_locations": ["Stone Face", "The Gathering", "The Crag", "The Shunned Vale"]
+      },
+      "expected": {
+        "location_count": 4
+      }
+    },
+    {
+      "id": "30.1.2_troll_locations_no_castles",
+      "rule_ref": "30.1.2",
+      "description": "Troll locations are cities without castles and can be entered freely",
+      "input": {
+        "troll_location": true
+      },
+      "expected": {
+        "intrinsic_defense": 0,
+        "enemy_entry_allowed": true
+      }
+    },
+    {
+      "id": "30.1.3_troll_monarch_start",
+      "rule_ref": "30.1.3",
+      "description": "Troll monarch starts at Stone Face",
+      "input": {
+        "monarch": "troll"
+      },
+      "expected": {
+        "starting_location": "Stone Face"
+      }
+    },
+    {
+      "id": "30.1.4_troll_regeneration",
+      "rule_ref": "30.1.4",
+      "description": "Trolls regenerate one eliminated regular at the start of each turn",
+      "input": {
+        "eliminated_regulars": 2,
+        "turn_phase": "start_of_turn",
+        "location_enemy_occupied": false
+      },
+      "expected": {
+        "units_regenerated": 1,
+        "eliminated_regulars_after": 1
+      }
+    },
+    {
+      "id": "30.1.4_troll_regeneration_blocked",
+      "rule_ref": "30.1.4",
+      "description": "Troll regeneration does not occur if the hex is enemy occupied",
+      "input": {
+        "eliminated_regulars": 1,
+        "turn_phase": "start_of_turn",
+        "location_enemy_occupied": true
+      },
+      "expected": {
+        "units_regenerated": 0
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "30.2.1_goblin_deploy_mountain_pass_only",
+      "rule_ref": "30.2.1",
+      "description": "Nithmere goblins deploy in Zorn mountain or pass hexes",
+      "input": {
+        "unit_type": "goblin_nithmere",
+        "terrain": "mountain",
+        "kingdom": "zorn"
+      },
+      "expected": {
+        "placement_allowed": true
+      }
+    },
+    {
+      "id": "30.2.1_goblin_one_per_hex",
+      "rule_ref": "30.2.1",
+      "description": "Only one Nithmere goblin may be placed per hex",
+      "input": {
+        "existing_goblin_in_hex": true
+      },
+      "expected": {
+        "placement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "30.2.1_goblin_no_adjacency",
+      "rule_ref": "30.2.1",
+      "description": "Nithmere goblins may not be deployed adjacent to each other",
+      "input": {
+        "proposed_hex": [20, 5],
+        "existing_goblin_hexes": [[20, 6], [21, 7]]
+      },
+      "expected": {
+        "placement_allowed": false,
+        "reason": "adjacent_to_existing_goblin"
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "30.3.1_dwarf_setup_locations",
+      "rule_ref": "30.3.1",
+      "description": "Dwarves have three separate setup locations",
+      "input": {
+        "dwarf_locations": ["Aws Noir", "Alzak", "Rosengg"]
+      },
+      "expected": {
+        "location_count": 3
+      }
+    },
+    {
+      "id": "30.3.2_dwarf_locations_listed",
+      "rule_ref": "30.3.2",
+      "description": "Dwarf locations are Aws Noir, Alzak, and Rosengg",
+      "input": {
+        "dwarf_locations": ["Aws Noir", "Alzak", "Rosengg"]
+      },
+      "expected": {
+        "locations_match": true
+      }
+    },
+    {
+      "id": "30.3.3_dwarf_unity_common_cause",
+      "rule_ref": "30.3.3",
+      "description": "Dwarf locations fight for a common cause",
+      "input": {
+        "dwarf_location": "Aws Noir",
+        "allied_with_other_dwarves": true
+      },
+      "expected": {
+        "treat_as_single_kingdom": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_5_special_rules/31_cities_vs_castles.json
+++ b/docs/conformance/chunk_5_special_rules/31_cities_vs_castles.json
@@ -1,0 +1,67 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "31_cities_vs_castles",
+  "tests": [
+    {
+      "id": "31.1_cities_vs_castles_distinction",
+      "rule_ref": "31.1",
+      "description": "Units deploy from cities, but only cities with castles provide intrinsic defense",
+      "input": {
+        "city_has_castle": false
+      },
+      "expected": {
+        "deployment_allowed": true,
+        "intrinsic_defense": 0
+      }
+    },
+    {
+      "id": "31.2.1_city_without_castle_example",
+      "rule_ref": "31.2.1",
+      "description": "Listed cities without castles are deployment hexes",
+      "input": {
+        "city_name": "Farnot",
+        "kingdom": "hothior"
+      },
+      "expected": {
+        "deployment_allowed": true,
+        "intrinsic_defense": 0
+      }
+    },
+    {
+      "id": "31.2.2_city_without_castle_no_siege",
+      "rule_ref": "31.2.2",
+      "description": "Cities without castles cannot be besieged",
+      "input": {
+        "city_has_castle": false,
+        "attempt_siege": true
+      },
+      "expected": {
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "31.3.1_castle_identified_in_hexmap",
+      "rule_ref": "31.3.1",
+      "description": "Castle locations are identified by castle markers in the hexmap",
+      "input": {
+        "hex_has_castle_marker": true
+      },
+      "expected": {
+        "is_castle": true
+      }
+    },
+    {
+      "id": "31.3.2_castle_provides_intrinsic_defense",
+      "rule_ref": "31.3.2",
+      "description": "Castles provide intrinsic defense strength for siege rules",
+      "input": {
+        "city_has_castle": true,
+        "intrinsic_defense": 4
+      },
+      "expected": {
+        "defense_strength": 4
+      }
+    }
+  ]
+}

--- a/docs/conformance/coverage_matrix.json
+++ b/docs/conformance/coverage_matrix.json
@@ -2,142 +2,999 @@
   "suite_version": "1.0.0",
   "description": "Maps rule references to test case IDs for coverage tracking",
   "rules": {
-    "4.1.2": ["4.1.2_monarch_not_combat_unit"],
-    "4.1.3": ["4.1.3_monarch_is_leader"],
-    "4.1.5": ["4.1.5_player_monarch_death_eliminates"],
-    "4.1.6": ["4.1.6_non_player_monarch_death_confusion"],
-    "4.2.2": ["4.2.2_ambassador_not_combat_unit"],
-    "4.2.3": ["4.2.3_ambassador_teleports"],
-    "4.2.4": ["4.2.4_ambassador_death_recovery"],
-    "4.3.2": ["4.3.2_regular_army_is_combat_unit"],
-    "4.3.3": ["4.3.3_regular_army_strength"],
-    "4.4.2": ["4.4.2_regular_fleet_is_combat_unit"],
-    "4.4.3": ["4.4.3_regular_fleet_strength"],
-    "4.4.5": ["4.4.5_regular_fleet_transport"],
-    "4.5.2": ["4.5.2_mercenary_army_is_combat_unit"],
-    "4.5.3": ["4.5.3_mercenary_army_strength"],
-    "4.6.2": ["4.6.2_mercenary_fleet_is_combat_unit"],
-    "4.6.3": ["4.6.3_mercenary_fleet_strength"],
-    "4.6.5": ["4.6.5_mercenary_fleet_transport"],
-    "5.2.1": ["5.2.1_hothior_is_human", "5.2.1_immer_is_human", "5.2.1_mivior_is_human", "5.2.1_muetar_is_human", "5.2.1_pon_is_human", "5.2.1_rombune_is_human", "5.2.1_shucassam_is_human"],
-    "5.2.2": ["5.2.2_human_retreat_success_rolls", "5.2.2_human_retreat_fails_on_three"],
-    "5.3.1": ["5.3.1_neuth_is_non_human", "5.3.1_ghem_is_non_human", "5.3.1_zorn_is_non_human", "5.3.1_trolls_is_non_human"],
-    "5.3.2": ["5.3.2_non_human_retreat_success_rolls", "5.3.2_non_human_retreat_fails_on_two"],
-    "5.4.1": ["5.4.1_mercenary_classification"],
-    "5.4.2": ["5.4.2_mercenary_retreat_success_rolls"],
-    "6.1.1": ["6.1.1_tree_symbol_forest_as_clear", "6.1.1_no_tree_symbol_forest_cost"],
-    "6.2.1": ["6.2.1_mountain_symbol_hills_as_clear", "6.2.1_no_mountain_symbol_hills_cost"],
-    "6.2.2": ["6.2.2_mountain_symbol_no_stop", "6.2.2_no_mountain_symbol_must_stop"],
-    "6.3.1": ["6.3.1_home_kingdom_bonus_applies_monarch", "6.3.1_home_kingdom_bonus_applies_regulars", "6.3.1_no_home_bonus_outside_kingdom", "6.3.1_no_home_bonus_mercenaries"],
-    "6.3.2": ["6.3.2_home_kingdom_both_bonuses"],
-    "19.1.1": ["19.1.1_clear_terrain_cost"],
-    "19.2.1": ["19.2.1_forest_terrain_cost"],
-    "19.2.2": ["19.2.2_forest_tree_symbol"],
-    "19.3.1": ["19.3.1_minor_river_cost"],
-    "19.3.2": ["19.3.2_minor_river_applies_all_directions"],
-    "19.4.1": ["19.4.1_major_river_crossing_requirement"],
-    "19.4.2": ["19.4.2_major_river_crossing_cost"],
-    "19.5.1": ["19.5.1_hills_terrain_cost"],
-    "19.5.2": ["19.5.2_hills_mountain_symbol"],
-    "19.6.1": ["19.6.1_mountain_terrain_cost"],
-    "19.6.2": ["19.6.2_mountain_must_stop"],
-    "19.6.3": ["19.6.3_mountain_combat_bonus"],
-    "19.6.4": ["19.6.4_mountain_symbol_no_stop"],
-    "19.7.1": ["19.7.1_lakeshore_cost"],
-    "19.7.2": ["19.7.2_lakeshore_no_crossing"],
-    "19.8.1": ["19.8.1_seashore_cost"],
-    "19.8.2": ["19.8.2_fleet_no_all_land_crossing"],
-    "19.8.3": ["19.8.3_land_no_all_sea_crossing"],
-    "19.9.1": ["19.9.1_open_sea_cost"],
-    "19.9.2": ["19.9.2_open_sea_fleets_only"],
-    "19.10.1": ["19.10.1_swamp_cost"],
-    "19.11.1": ["19.11.1_isle_of_fright_cost"],
-    "19.11.2": ["19.11.2_isle_of_fright_restriction"],
-    "19.12.1": ["19.12.1_mountain_pass_cost"],
-    "19.12.2": ["19.12.2_mountain_pass_defender_doubled"],
-    "19.13.1": ["19.13.1_castle_enemy_forbidden"],
-    "19.13.2": ["19.13.2_castle_friendly_cost"],
-    "19.14.2": ["19.14.2_seaport_cost"],
-    "19.14.3": ["19.14.3_seaport_access"],
-    "19.16.1": ["19.16.1_scenic_hex_cost"],
-    "19.17.1": ["19.17.1_cumulative_terrain_rule"],
-    "19.17.2": ["19.17.2_forested_mountain_cost"],
-    "18.1.1": ["18.1.1_only_active_player_moves"],
-    "18.1.2": ["18.1.2_any_direction_movement"],
-    "18.1.3": ["18.1.3_movement_points_not_saved"],
-    "18.1.4": ["18.1.4_minimum_movement_one_hex"],
-    "18.2.1": ["18.2.1_player_monarch_units_may_move"],
-    "18.2.2": ["18.2.2_friendly_mercenaries_may_move"],
-    "18.2.3": ["18.2.3_allied_kingdom_units_may_move"],
-    "18.3.1": ["18.3.1_besieged_units_cannot_move"],
-    "18.3.2": ["18.3.2_just_activated_cannot_move"],
-    "18.3.3": ["18.3.3_just_deactivated_cannot_move"],
-    "18.4.1": ["18.4.1_stack_uses_slowest_speed"],
-    "18.4.2": ["18.4.2_units_may_leave_stack"],
-    "18.4.3": ["18.4.3_units_may_continue_independently"],
-    "18.5.1": ["18.5.1_cannot_enter_enemy_hex"],
-    "18.5.2": ["18.5.2_allied_stacking_end_turn"],
-    "18.5.3": ["18.5.3_cannot_exceed_allowance"],
-    "18.5.4": ["18.5.4_terrain_cost_exceeds_remaining"],
-    "18.5.5": ["18.5.5_land_cannot_cross_all_sea", "18.5.5_fleet_cannot_cross_all_land"],
-    "18.5.6": ["18.5.6_off_map_eliminates", "18.5.6_voluntary_off_map_forbidden"],
-    "25.1.1": ["25.1.1_only_active_player_attacks"],
-    "25.1.2": ["25.1.2_adjacency_required"],
-    "25.1.3": ["25.1.3_attack_is_optional"],
-    "25.2.1": ["25.2.1_retreat_timing"],
-    "25.2.2": ["25.2.2_human_retreat_success", "25.2.2_human_retreat_failure", "25.2.2_non_human_retreat_success"],
-    "25.2.3": ["25.2.3_stack_test_order"],
-    "25.2.4": ["25.2.4_retreat_destination"],
-    "25.2.5": ["25.2.5_same_hex_retreat"],
-    "25.2.9": ["25.2.9_no_retreat_if_surrounded"],
-    "25.2.10": ["25.2.10_no_second_retreat"],
-    "25.2.11": ["25.2.11_attacker_advance_after_retreat"],
-    "25.3.1": ["25.3.1_both_sides_roll"],
-    "25.3.2": ["25.3.2_higher_roll_wins"],
-    "25.3.3": ["25.3.3_loser_losses"],
-    "25.3.4": ["25.3.4_tie_both_lose"],
-    "25.3.5": ["25.3.5_loss_selection"],
-    "25.4.1": ["25.4.1_combat_modifier_attacker_advantage", "25.4.1_equal_forces_no_modifier"],
-    "25.4.2": ["25.4.2_combat_modifier_fractions_dropped"],
-    "25.4.4": ["25.4.4_defender_minimum_bonus", "25.4.4_defender_formula_exceeds_minimum"],
-    "25.5.1": ["25.5.1_all_attacks_declared_first"],
-    "25.5.2": ["25.5.2_attacker_chooses_resolution_order"],
-    "25.5.3": ["25.5.3_results_immediate"],
-    "25.6.1": ["25.6.1_seaborne_units_eliminated"],
-    "25.7.2": ["25.7.2_siege_attackers_cannot_combat", "25.7.2_transported_units_no_combat", "25.7.2_activated_kingdom_no_attack", "25.7.2_deactivated_kingdom_no_attack"],
-    "25.8.1": ["25.8.1_cannot_attack_inside_castle"],
-    "25.8.2": ["25.8.2_adjacency_required_for_attack"],
-    "25.9.1": ["25.9.1_multiple_hexes_combine"],
-    "25.9.2": ["25.9.2_allied_forces_combine"],
-    "25.10.1": ["25.10.1_unit_attack_limit"],
-    "25.10.2": ["25.10.2_hex_attack_limit"],
-    "25.11.1": ["25.11.1_mountain_defender_bonus"],
-    "25.11.2": ["25.11.2_mountain_pass_doubles_defender"],
-    "25.11.4": ["25.11.4_land_no_attack_across_sea", "25.11.4_fleet_no_attack_across_land"],
-    "25.12.1": ["25.12.1_stack_attack_rule"],
-    "25.12.2": ["25.12.2_stack_split_attacks"],
-    "25.12.3": ["25.12.3_all_defenders_attacked"],
-    "25.13.1": ["25.13.1_advance_trigger"],
-    "25.13.2": ["25.13.2_advance_units_choice"],
-    "25.13.3": ["25.13.3_advance_one_hex_only"],
-    "25.13.4": ["25.13.4_siege_relief_advance_two"],
-    "26.1": ["26.1.1_monarchs_are_leaders"],
-    "26.2": ["26.2.1_leader_combat_strength_zero"],
-    "26.3.1": ["26.3.1_leader_movement_bonus_scope"],
-    "26.3.2": ["26.3.2_stack_uses_leader_ma"],
-    "26.3.3": ["26.3.3_begin_end_stacked"],
-    "26.3.4": ["26.3.4_units_may_be_left_behind"],
-    "26.3.5": ["26.3.5_no_independent_movement_with_leader"],
-    "26.3.6": ["26.3.6_unit_terrain_no_transfer"],
-    "26.4.1": ["26.4.1_leader_combat_bonus_source"],
-    "26.4.2": ["26.4.2_multiple_leader_bonuses_stack"],
-    "26.4.3": ["26.4.3_no_leader_bonus_in_siege"],
-    "26.5.1": ["26.5.1_lone_leader_pass_through_enemy"],
-    "26.5.2": ["26.5.2_lone_leader_requires_fate_roll"],
-    "26.6.1": ["26.6.1_fate_roll_combat_loss", "26.6.1_fate_roll_lone_leader_enemy_pass", "26.6.1_fate_roll_enemy_passes_lone_leader", "26.6.1_fate_roll_castle_falls", "26.6.1_fate_roll_leave_besieged_alone", "26.6.1_fate_roll_fleet_lost_at_sea"],
-    "26.6.2": ["26.6.2_fate_roll_one_killed", "26.6.2_fate_roll_two_to_five_no_effect", "26.6.2_fate_roll_six_captured"],
-    "26.6.3": ["26.6.3_fate_roll_once_per_player_turn", "26.6.3_fate_roll_once_per_enemy_phase"],
-    "26.6.5": ["26.6.5_any_unit_may_force_fate_roll"],
-    "26.7": ["26.7.1_lone_leader_cannot_be_attacked"]
+    "4.1.2": [
+      "4.1.2_monarch_not_combat_unit"
+    ],
+    "4.1.3": [
+      "4.1.3_monarch_is_leader"
+    ],
+    "4.1.5": [
+      "4.1.5_player_monarch_death_eliminates"
+    ],
+    "4.1.6": [
+      "4.1.6_non_player_monarch_death_confusion"
+    ],
+    "4.2.2": [
+      "4.2.2_ambassador_not_combat_unit"
+    ],
+    "4.2.3": [
+      "4.2.3_ambassador_teleports"
+    ],
+    "4.2.4": [
+      "4.2.4_ambassador_death_recovery"
+    ],
+    "4.3.2": [
+      "4.3.2_regular_army_is_combat_unit"
+    ],
+    "4.3.3": [
+      "4.3.3_regular_army_strength"
+    ],
+    "4.4.2": [
+      "4.4.2_regular_fleet_is_combat_unit"
+    ],
+    "4.4.3": [
+      "4.4.3_regular_fleet_strength"
+    ],
+    "4.4.5": [
+      "4.4.5_regular_fleet_transport"
+    ],
+    "4.5.2": [
+      "4.5.2_mercenary_army_is_combat_unit"
+    ],
+    "4.5.3": [
+      "4.5.3_mercenary_army_strength"
+    ],
+    "4.6.2": [
+      "4.6.2_mercenary_fleet_is_combat_unit"
+    ],
+    "4.6.3": [
+      "4.6.3_mercenary_fleet_strength"
+    ],
+    "4.6.5": [
+      "4.6.5_mercenary_fleet_transport"
+    ],
+    "5.2.1": [
+      "5.2.1_hothior_is_human",
+      "5.2.1_immer_is_human",
+      "5.2.1_mivior_is_human",
+      "5.2.1_muetar_is_human",
+      "5.2.1_pon_is_human",
+      "5.2.1_rombune_is_human",
+      "5.2.1_shucassam_is_human"
+    ],
+    "5.2.2": [
+      "5.2.2_human_retreat_success_rolls",
+      "5.2.2_human_retreat_fails_on_three"
+    ],
+    "5.3.1": [
+      "5.3.1_neuth_is_non_human",
+      "5.3.1_ghem_is_non_human",
+      "5.3.1_zorn_is_non_human",
+      "5.3.1_trolls_is_non_human"
+    ],
+    "5.3.2": [
+      "5.3.2_non_human_retreat_success_rolls",
+      "5.3.2_non_human_retreat_fails_on_two"
+    ],
+    "5.4.1": [
+      "5.4.1_mercenary_classification"
+    ],
+    "5.4.2": [
+      "5.4.2_mercenary_retreat_success_rolls"
+    ],
+    "6.1.1": [
+      "6.1.1_tree_symbol_forest_as_clear",
+      "6.1.1_no_tree_symbol_forest_cost"
+    ],
+    "6.2.1": [
+      "6.2.1_mountain_symbol_hills_as_clear",
+      "6.2.1_no_mountain_symbol_hills_cost"
+    ],
+    "6.2.2": [
+      "6.2.2_mountain_symbol_no_stop",
+      "6.2.2_no_mountain_symbol_must_stop"
+    ],
+    "6.3.1": [
+      "6.3.1_home_kingdom_bonus_applies_monarch",
+      "6.3.1_home_kingdom_bonus_applies_regulars",
+      "6.3.1_no_home_bonus_outside_kingdom",
+      "6.3.1_no_home_bonus_mercenaries"
+    ],
+    "6.3.2": [
+      "6.3.2_home_kingdom_both_bonuses"
+    ],
+    "8.1": [
+      "8.1_random_event_roll_two_dice"
+    ],
+    "8.2.1": [
+      "8.2.1_roll_two_untimely_death"
+    ],
+    "8.2.2": [
+      "8.2.2_roll_three_storms"
+    ],
+    "8.2.3": [
+      "8.2.3_roll_four_mutiny"
+    ],
+    "8.2.4": [
+      "8.2.4_roll_five_bad_omens"
+    ],
+    "8.2.5": [
+      "8.2.5_roll_six_replacements"
+    ],
+    "8.2.6": [
+      "8.2.6_roll_seven_no_event"
+    ],
+    "8.2.7": [
+      "8.2.7_roll_eight_reinforcements"
+    ],
+    "8.2.8": [
+      "8.2.8_roll_nine_plague"
+    ],
+    "8.2.9": [
+      "8.2.9_roll_ten_replacement"
+    ],
+    "8.2.10": [
+      "8.2.10_roll_eleven_desertion"
+    ],
+    "8.2.11": [
+      "8.2.11_roll_twelve_help_from_afar"
+    ],
+    "8.3.1": [
+      "8.3.1_event_applies_only_to_roller"
+    ],
+    "8.3.2": [
+      "8.3.2_regular_placement_at_counter"
+    ],
+    "8.3.3": [
+      "8.3.3_blocked_placement_fails"
+    ],
+    "8.3.4": [
+      "8.3.4_mercenary_placement_friendly"
+    ],
+    "8.3.5": [
+      "8.3.5_fleet_reinforcement_requires_port"
+    ],
+    "8.3.6": [
+      "8.3.6_regular_limit_respected"
+    ],
+    "8.3.7": [
+      "8.3.7_immediate_action_for_replacements"
+    ],
+    "8.3.8": [
+      "8.3.8_impossible_event_no_event"
+    ],
+    "8.3.9": [
+      "8.3.9_no_transfer_between_players"
+    ],
+    "12.1.1": [
+      "12.1.1_diplomacy_only_between"
+    ],
+    "12.1.2": [
+      "12.1.2_player_alliances_not_binding"
+    ],
+    "12.1.3": [
+      "12.1.3_ambassador_death_recovery_turns"
+    ],
+    "12.1.4": [
+      "12.1.4_ambassador_teleport_movement"
+    ],
+    "12.1.5": [
+      "12.1.5_ambassador_return_blocked"
+    ],
+    "12.2.1": [
+      "12.2.1_threshold_comparison"
+    ],
+    "12.2.2": [
+      "12.2.2_card_played_before_roll"
+    ],
+    "12.2.3": [
+      "12.2.3_modified_result_formula"
+    ],
+    "12.2.4": [
+      "12.2.4_automatic_success"
+    ],
+    "12.3.1": [
+      "12.3.1_activate_neutral_threshold",
+      "12.3.1_activate_neutral_effects"
+    ],
+    "12.3.2": [
+      "12.3.2_deactivate_threshold",
+      "12.3.2_deactivate_effects"
+    ],
+    "12.3.3": [
+      "12.3.3_assassination_limit_once",
+      "12.3.3_assassination_higher_roll_kills"
+    ],
+    "12.3.4": [
+      "12.3.4_duel_limit_once",
+      "12.3.4_duel_tie_kills_both"
+    ],
+    "12.4.1": [
+      "12.4.1_ambassador_death_removal"
+    ],
+    "12.4.3": [
+      "12.4.3_no_diplomacy_during_death"
+    ],
+    "12.4.4": [
+      "12.4.4_ambassador_recovery_turn"
+    ],
+    "12.4.5": [
+      "12.4.5_penalties_inherited"
+    ],
+    "12.4.6": [
+      "12.4.6_continue_card_draw"
+    ],
+    "12.5.1": [
+      "12.5.1_banishment_triggering_cards"
+    ],
+    "12.5.2": [
+      "12.5.2_banishment_on_failed_roll"
+    ],
+    "12.5.3": [
+      "12.5.3_banishment_duration_formula"
+    ],
+    "12.5.4": [
+      "12.5.4_banishment_effect"
+    ],
+    "12.5.5": [
+      "12.5.5_multiple_banishments_add"
+    ],
+    "12.5.6": [
+      "12.5.6_card_discard_before_result"
+    ],
+    "12.6.1": [
+      "12.6.1_penalty_trigger_border_violation"
+    ],
+    "12.6.2": [
+      "12.6.2_penalty_effect_minus_one"
+    ],
+    "12.6.3": [
+      "12.6.3_penalty_exceptions"
+    ],
+    "12.6.4": [
+      "12.6.4_penalty_not_cumulative"
+    ],
+    "12.6.5": [
+      "12.6.5_deactivation_grace_period"
+    ],
+    "12.6.6": [
+      "12.6.6_voluntary_elimination_avoids_penalty"
+    ],
+    "13.1": [
+      "13.1_total_cards"
+    ],
+    "13.2": [
+      "13.2_basic_game_cards"
+    ],
+    "13.3.1": [
+      "13.3.1_diplomatic_ploys_bonus"
+    ],
+    "13.3.2": [
+      "13.3.2_special_mercenary_count"
+    ],
+    "13.4": [
+      "13.4_cards_accumulate"
+    ],
+    "13.5": [
+      "13.5_cards_not_tradable"
+    ],
+    "13.6": [
+      "13.6_reshuffle_when_exhausted"
+    ],
+    "13.7": [
+      "13.7_discard_after_use"
+    ],
+    "14.1": [
+      "14.1_total_personality_cards"
+    ],
+    "14.2": [
+      "14.2_assignment_one_per_monarch"
+    ],
+    "14.3": [
+      "14.3_reveal_on_ambassador_visit"
+    ],
+    "14.4": [
+      "14.4_personality_effects_apply"
+    ],
+    "17.1.1": [
+      "17.1.1_castle_surrounded_required"
+    ],
+    "17.1.2": [
+      "17.1.2_no_outside_defenders"
+    ],
+    "17.1.3": [
+      "17.1.3_sufficient_force"
+    ],
+    "17.2": [
+      "17.2_cooperation_rule_no_combined_strength"
+    ],
+    "17.3.1": [
+      "17.3.1_zone_extends_adjacent"
+    ],
+    "17.3.2": [
+      "17.3.2_zone_all_sea_only"
+    ],
+    "17.3.3": [
+      "17.3.3_zone_all_land_only"
+    ],
+    "17.3.4": [
+      "17.3.4_zone_not_negated_by_friendly_units"
+    ],
+    "17.4.1": [
+      "17.4.1_units_inside_tracked"
+    ],
+    "17.4.2": [
+      "17.4.2_outside_units_must_be_eliminated"
+    ],
+    "17.4.3": [
+      "17.4.3_outside_units_attacked_in_combat_phase"
+    ],
+    "17.4.4": [
+      "17.4.4_retreat_into_castle_before_combat"
+    ],
+    "17.4.5": [
+      "17.4.5_leader_bonus_not_outside"
+    ],
+    "17.4.6": [
+      "17.4.6_move_in_out_no_cost"
+    ],
+    "17.4.7": [
+      "17.4.7_move_only_during_movement_phase"
+    ],
+    "17.5.1": [
+      "17.5.1_intrinsic_defense_from_hex"
+    ],
+    "17.5.2": [
+      "17.5.2_intrinsic_defense_only_for_siege"
+    ],
+    "17.5.3": [
+      "17.5.3_intact_castle_blocks_entry"
+    ],
+    "17.5.4": [
+      "17.5.4_plundered_castle_no_defense"
+    ],
+    "17.6.1": [
+      "17.6.1_siege_declared_when_conditions_met"
+    ],
+    "17.6.2": [
+      "17.6.2_any_player_may_declare"
+    ],
+    "17.6.3": [
+      "17.6.3_retreat_before_combat_not_besieging"
+    ],
+    "17.7.1": [
+      "17.7.1_reinforcements_blocked"
+    ],
+    "17.7.2": [
+      "17.7.2_must_attack_besiegers_first",
+      "17.7.2_leave_siege_after_resolution"
+    ],
+    "17.7.3": [
+      "17.7.3_attack_from_siege_combat_phase",
+      "17.7.3_attack_from_siege_advance_limit",
+      "17.7.3_outside_forces_join",
+      "17.7.3_attack_from_siege_breaks_siege"
+    ],
+    "17.8.1": [
+      "17.8.1_resolution_in_siege_phase"
+    ],
+    "17.8.2": [
+      "17.8.2_siege_roll_single_die"
+    ],
+    "17.8.3": [
+      "17.8.3_siege_roll_one_to_five_no_effect"
+    ],
+    "17.8.4": [
+      "17.8.4_siege_roll_six_taken"
+    ],
+    "17.8.5": [
+      "17.8.5_siege_attackers_no_move_after"
+    ],
+    "17.9.1": [
+      "17.9.1_siege_modifier_formula"
+    ],
+    "17.9.2": [
+      "17.9.2_siege_modifier_drop_fraction"
+    ],
+    "17.9.3": [
+      "17.9.3_siege_modifier_applies_to_attacker"
+    ],
+    "17.9.4": [
+      "17.9.4_siege_modifier_example_one"
+    ],
+    "17.9.5": [
+      "17.9.5_siege_modifier_example_two"
+    ],
+    "17.9.6": [
+      "17.9.6_siege_modifier_example_three"
+    ],
+    "17.10.1": [
+      "17.10.1_plundered_castle_nonexistent"
+    ],
+    "17.10.2": [
+      "17.10.2_plundered_castle_placement_hex"
+    ],
+    "17.10.3": [
+      "17.10.3_plundered_royal_castle_diplomacy"
+    ],
+    "17.10.4": [
+      "17.10.4_plundered_castle_makes_friendly"
+    ],
+    "17.10.5": [
+      "17.10.5_plundered_castle_permanent"
+    ],
+    "17.11.1": [
+      "17.11.1_fleets_participate_in_siege"
+    ],
+    "17.11.2": [
+      "17.11.2_fleet_cannot_attack_all_land"
+    ],
+    "17.11.3": [
+      "17.11.3_port_siege_requires_fleet"
+    ],
+    "17.11.4": [
+      "17.11.4_port_siege_zone_coverage"
+    ],
+    "17.11.5": [
+      "17.11.5_seaborne_units_count_in_siege"
+    ],
+    "17.12.1": [
+      "17.12.1_relief_force_procedure"
+    ],
+    "17.12.2": [
+      "17.12.2_relief_force_two_hex_advance"
+    ],
+    "17.12.3": [
+      "17.12.3_relief_force_post_options"
+    ],
+    "17.13.1": [
+      "17.13.1_forced_peace_trigger"
+    ],
+    "17.13.2": [
+      "17.13.2_forced_peace_roll_timing"
+    ],
+    "17.13.3": [
+      "17.13.3_forced_peace_special_roll"
+    ],
+    "17.13.5": [
+      "17.13.5_forced_peace_success_rolls"
+    ],
+    "17.13.6": [
+      "17.13.6_forced_peace_contested_modifier"
+    ],
+    "17.13.7": [
+      "17.13.7_forced_peace_no_modifiers"
+    ],
+    "17.13.8": [
+      "17.13.8_forced_peace_alternative_normal_diplomacy"
+    ],
+    "17.13.9": [
+      "17.13.9_forced_peace_effects"
+    ],
+    "17.13.10": [
+      "17.13.10_forced_peace_violation_effect"
+    ],
+    "17.13.11": [
+      "17.13.11_forced_peace_unit_status"
+    ],
+    "17.13.12": [
+      "17.13.12_plundered_castles_remain"
+    ],
+    "17.13.13": [
+      "17.13.13_player_monarchs_not_subject"
+    ],
+    "18.1.1": [
+      "18.1.1_only_active_player_moves"
+    ],
+    "18.1.2": [
+      "18.1.2_any_direction_movement"
+    ],
+    "18.1.3": [
+      "18.1.3_movement_points_not_saved"
+    ],
+    "18.1.4": [
+      "18.1.4_minimum_movement_one_hex"
+    ],
+    "18.2.1": [
+      "18.2.1_player_monarch_units_may_move"
+    ],
+    "18.2.2": [
+      "18.2.2_friendly_mercenaries_may_move"
+    ],
+    "18.2.3": [
+      "18.2.3_allied_kingdom_units_may_move"
+    ],
+    "18.3.1": [
+      "18.3.1_besieged_units_cannot_move"
+    ],
+    "18.3.2": [
+      "18.3.2_just_activated_cannot_move"
+    ],
+    "18.3.3": [
+      "18.3.3_just_deactivated_cannot_move"
+    ],
+    "18.4.1": [
+      "18.4.1_stack_uses_slowest_speed"
+    ],
+    "18.4.2": [
+      "18.4.2_units_may_leave_stack"
+    ],
+    "18.4.3": [
+      "18.4.3_units_may_continue_independently"
+    ],
+    "18.5.1": [
+      "18.5.1_cannot_enter_enemy_hex"
+    ],
+    "18.5.2": [
+      "18.5.2_allied_stacking_end_turn"
+    ],
+    "18.5.3": [
+      "18.5.3_cannot_exceed_allowance"
+    ],
+    "18.5.4": [
+      "18.5.4_terrain_cost_exceeds_remaining"
+    ],
+    "18.5.5": [
+      "18.5.5_land_cannot_cross_all_sea",
+      "18.5.5_fleet_cannot_cross_all_land"
+    ],
+    "18.5.6": [
+      "18.5.6_off_map_eliminates",
+      "18.5.6_voluntary_off_map_forbidden"
+    ],
+    "19.1.1": [
+      "19.1.1_clear_terrain_cost"
+    ],
+    "19.2.1": [
+      "19.2.1_forest_terrain_cost"
+    ],
+    "19.2.2": [
+      "19.2.2_forest_tree_symbol"
+    ],
+    "19.3.1": [
+      "19.3.1_minor_river_cost"
+    ],
+    "19.3.2": [
+      "19.3.2_minor_river_applies_all_directions"
+    ],
+    "19.4.1": [
+      "19.4.1_major_river_crossing_requirement"
+    ],
+    "19.4.2": [
+      "19.4.2_major_river_crossing_cost"
+    ],
+    "19.5.1": [
+      "19.5.1_hills_terrain_cost"
+    ],
+    "19.5.2": [
+      "19.5.2_hills_mountain_symbol"
+    ],
+    "19.6.1": [
+      "19.6.1_mountain_terrain_cost"
+    ],
+    "19.6.2": [
+      "19.6.2_mountain_must_stop"
+    ],
+    "19.6.3": [
+      "19.6.3_mountain_combat_bonus"
+    ],
+    "19.6.4": [
+      "19.6.4_mountain_symbol_no_stop"
+    ],
+    "19.7.1": [
+      "19.7.1_lakeshore_cost"
+    ],
+    "19.7.2": [
+      "19.7.2_lakeshore_no_crossing"
+    ],
+    "19.8.1": [
+      "19.8.1_seashore_cost"
+    ],
+    "19.8.2": [
+      "19.8.2_fleet_no_all_land_crossing"
+    ],
+    "19.8.3": [
+      "19.8.3_land_no_all_sea_crossing"
+    ],
+    "19.9.1": [
+      "19.9.1_open_sea_cost"
+    ],
+    "19.9.2": [
+      "19.9.2_open_sea_fleets_only"
+    ],
+    "19.10.1": [
+      "19.10.1_swamp_cost"
+    ],
+    "19.11.1": [
+      "19.11.1_isle_of_fright_cost"
+    ],
+    "19.11.2": [
+      "19.11.2_isle_of_fright_restriction"
+    ],
+    "19.12.1": [
+      "19.12.1_mountain_pass_cost"
+    ],
+    "19.12.2": [
+      "19.12.2_mountain_pass_defender_doubled"
+    ],
+    "19.13.1": [
+      "19.13.1_castle_enemy_forbidden"
+    ],
+    "19.13.2": [
+      "19.13.2_castle_friendly_cost"
+    ],
+    "19.14.2": [
+      "19.14.2_seaport_cost"
+    ],
+    "19.14.3": [
+      "19.14.3_seaport_access"
+    ],
+    "19.16.1": [
+      "19.16.1_scenic_hex_cost"
+    ],
+    "19.17.1": [
+      "19.17.1_cumulative_terrain_rule"
+    ],
+    "19.17.2": [
+      "19.17.2_forested_mountain_cost"
+    ],
+    "25.1.1": [
+      "25.1.1_only_active_player_attacks"
+    ],
+    "25.1.2": [
+      "25.1.2_adjacency_required"
+    ],
+    "25.1.3": [
+      "25.1.3_attack_is_optional"
+    ],
+    "25.2.1": [
+      "25.2.1_retreat_timing"
+    ],
+    "25.2.2": [
+      "25.2.2_human_retreat_success",
+      "25.2.2_human_retreat_failure",
+      "25.2.2_non_human_retreat_success"
+    ],
+    "25.2.3": [
+      "25.2.3_stack_test_order"
+    ],
+    "25.2.4": [
+      "25.2.4_retreat_destination"
+    ],
+    "25.2.5": [
+      "25.2.5_same_hex_retreat"
+    ],
+    "25.2.9": [
+      "25.2.9_no_retreat_if_surrounded"
+    ],
+    "25.2.10": [
+      "25.2.10_no_second_retreat"
+    ],
+    "25.2.11": [
+      "25.2.11_attacker_advance_after_retreat"
+    ],
+    "25.3.1": [
+      "25.3.1_both_sides_roll"
+    ],
+    "25.3.2": [
+      "25.3.2_higher_roll_wins"
+    ],
+    "25.3.3": [
+      "25.3.3_loser_losses"
+    ],
+    "25.3.4": [
+      "25.3.4_tie_both_lose"
+    ],
+    "25.3.5": [
+      "25.3.5_loss_selection"
+    ],
+    "25.4.1": [
+      "25.4.1_combat_modifier_attacker_advantage",
+      "25.4.1_equal_forces_no_modifier"
+    ],
+    "25.4.2": [
+      "25.4.2_combat_modifier_fractions_dropped"
+    ],
+    "25.4.4": [
+      "25.4.4_defender_minimum_bonus",
+      "25.4.4_defender_formula_exceeds_minimum"
+    ],
+    "25.5.1": [
+      "25.5.1_all_attacks_declared_first"
+    ],
+    "25.5.2": [
+      "25.5.2_attacker_chooses_resolution_order"
+    ],
+    "25.5.3": [
+      "25.5.3_results_immediate"
+    ],
+    "25.6.1": [
+      "25.6.1_seaborne_units_eliminated"
+    ],
+    "25.7.2": [
+      "25.7.2_siege_attackers_cannot_combat",
+      "25.7.2_transported_units_no_combat",
+      "25.7.2_activated_kingdom_no_attack",
+      "25.7.2_deactivated_kingdom_no_attack"
+    ],
+    "25.8.1": [
+      "25.8.1_cannot_attack_inside_castle"
+    ],
+    "25.8.2": [
+      "25.8.2_adjacency_required_for_attack"
+    ],
+    "25.9.1": [
+      "25.9.1_multiple_hexes_combine"
+    ],
+    "25.9.2": [
+      "25.9.2_allied_forces_combine"
+    ],
+    "25.10.1": [
+      "25.10.1_unit_attack_limit"
+    ],
+    "25.10.2": [
+      "25.10.2_hex_attack_limit"
+    ],
+    "25.11.1": [
+      "25.11.1_mountain_defender_bonus"
+    ],
+    "25.11.2": [
+      "25.11.2_mountain_pass_doubles_defender"
+    ],
+    "25.11.4": [
+      "25.11.4_land_no_attack_across_sea",
+      "25.11.4_fleet_no_attack_across_land"
+    ],
+    "25.12.1": [
+      "25.12.1_stack_attack_rule"
+    ],
+    "25.12.2": [
+      "25.12.2_stack_split_attacks"
+    ],
+    "25.12.3": [
+      "25.12.3_all_defenders_attacked"
+    ],
+    "25.13.1": [
+      "25.13.1_advance_trigger"
+    ],
+    "25.13.2": [
+      "25.13.2_advance_units_choice"
+    ],
+    "25.13.3": [
+      "25.13.3_advance_one_hex_only"
+    ],
+    "25.13.4": [
+      "25.13.4_siege_relief_advance_two"
+    ],
+    "26.1": [
+      "26.1.1_monarchs_are_leaders"
+    ],
+    "26.2": [
+      "26.2.1_leader_combat_strength_zero"
+    ],
+    "26.3.1": [
+      "26.3.1_leader_movement_bonus_scope"
+    ],
+    "26.3.2": [
+      "26.3.2_stack_uses_leader_ma"
+    ],
+    "26.3.3": [
+      "26.3.3_begin_end_stacked"
+    ],
+    "26.3.4": [
+      "26.3.4_units_may_be_left_behind"
+    ],
+    "26.3.5": [
+      "26.3.5_no_independent_movement_with_leader"
+    ],
+    "26.3.6": [
+      "26.3.6_unit_terrain_no_transfer"
+    ],
+    "26.4.1": [
+      "26.4.1_leader_combat_bonus_source"
+    ],
+    "26.4.2": [
+      "26.4.2_multiple_leader_bonuses_stack"
+    ],
+    "26.4.3": [
+      "26.4.3_no_leader_bonus_in_siege"
+    ],
+    "26.5.1": [
+      "26.5.1_lone_leader_pass_through_enemy"
+    ],
+    "26.5.2": [
+      "26.5.2_lone_leader_requires_fate_roll"
+    ],
+    "26.6.1": [
+      "26.6.1_fate_roll_combat_loss",
+      "26.6.1_fate_roll_lone_leader_enemy_pass",
+      "26.6.1_fate_roll_enemy_passes_lone_leader",
+      "26.6.1_fate_roll_castle_falls",
+      "26.6.1_fate_roll_leave_besieged_alone",
+      "26.6.1_fate_roll_fleet_lost_at_sea"
+    ],
+    "26.6.2": [
+      "26.6.2_fate_roll_one_killed",
+      "26.6.2_fate_roll_two_to_five_no_effect",
+      "26.6.2_fate_roll_six_captured"
+    ],
+    "26.6.3": [
+      "26.6.3_fate_roll_once_per_player_turn",
+      "26.6.3_fate_roll_once_per_enemy_phase"
+    ],
+    "26.6.5": [
+      "26.6.5_any_unit_may_force_fate_roll"
+    ],
+    "26.7": [
+      "26.7.1_lone_leader_cannot_be_attacked"
+    ],
+    "28.1.1": [
+      "28.1.1_non_player_death_confusion"
+    ],
+    "28.1.2": [
+      "28.1.2_confusion_duration_roll"
+    ],
+    "28.1.3": [
+      "28.1.3_confusion_restricts_regulars"
+    ],
+    "28.1.4": [
+      "28.1.4_confusion_end_new_personality"
+    ],
+    "28.1.5": [
+      "28.1.5_border_violation_ends_confusion"
+    ],
+    "28.1.6": [
+      "28.1.6_eliminated_regulars_remain"
+    ],
+    "28.2.1": [
+      "28.2.1_player_monarch_death_eliminates_player"
+    ],
+    "28.2.2": [
+      "28.2.2_allies_deactivate"
+    ],
+    "28.2.3": [
+      "28.2.3_player_kingdom_confusion"
+    ],
+    "28.2.4": [
+      "28.2.4_after_confusion_new_monarch"
+    ],
+    "28.2.5": [
+      "28.2.5_player_keeps_victory_points"
+    ],
+    "28.2.6": [
+      "28.2.6_eliminated_player_can_win"
+    ],
+    "28.2.7": [
+      "28.2.7_reentry_requires_approval"
+    ],
+    "28.3.1": [
+      "28.3.1_prisoner_placed_nearest_castle"
+    ],
+    "28.3.2": [
+      "28.3.2_no_castle_options"
+    ],
+    "28.3.3": [
+      "28.3.3_capture_awards_points"
+    ],
+    "28.3.4": [
+      "28.3.4_prisoner_cannot_act"
+    ],
+    "28.3.5": [
+      "28.3.5_release_conditions"
+    ],
+    "28.3.6": [
+      "28.3.6_release_placement"
+    ],
+    "28.4.1": [
+      "28.4.1_execute_prisoner_timing"
+    ],
+    "28.4.2": [
+      "28.4.2_execute_prisoner_no_points"
+    ],
+    "28.4.3": [
+      "28.4.3_execute_prisoner_penalty"
+    ],
+    "28.5.1": [
+      "28.5.1_forced_peace_timing"
+    ],
+    "28.5.3": [
+      "28.5.3_forced_peace_success_rolls"
+    ],
+    "28.5.4": [
+      "28.5.4_forced_peace_siege_modifier"
+    ],
+    "28.5.5": [
+      "28.5.5_forced_peace_no_modifiers"
+    ],
+    "28.5.6": [
+      "28.5.6_forced_peace_alternative_diplomacy"
+    ],
+    "28.5.7": [
+      "28.5.7_forced_peace_only_jailer"
+    ],
+    "28.5.8": [
+      "28.5.8_forced_peace_effects_reference"
+    ],
+    "29.1": [
+      "29.1_victory_points_determine_winner"
+    ],
+    "29.2": [
+      "29.2_timed_victory_after_twenty_turns"
+    ],
+    "29.3.1": [
+      "29.3.1_plunder_castle_points"
+    ],
+    "29.3.2": [
+      "29.3.2_plunder_royal_castle_points"
+    ],
+    "29.3.3": [
+      "29.3.3_capture_enemy_allied_monarch"
+    ],
+    "29.3.4": [
+      "29.3.4_kill_enemy_allied_monarch"
+    ],
+    "29.3.5": [
+      "29.3.5_capture_or_kill_player_monarch"
+    ],
+    "29.4.1": [
+      "29.4.1_assassination_kill_no_points"
+    ],
+    "29.4.2": [
+      "29.4.2_execute_prisoner_no_points"
+    ],
+    "29.4.3": [
+      "29.4.3_plunder_once_per_castle"
+    ],
+    "29.4.4": [
+      "29.4.4_plundered_status_permanent"
+    ],
+    "29.4.5": [
+      "29.4.5_capture_escape_recapture_points"
+    ],
+    "29.4.6": [
+      "29.4.6_posthumous_victory"
+    ],
+    "30.1.1": [
+      "30.1.1_troll_setup_locations"
+    ],
+    "30.1.2": [
+      "30.1.2_troll_locations_no_castles"
+    ],
+    "30.1.3": [
+      "30.1.3_troll_monarch_start"
+    ],
+    "30.1.4": [
+      "30.1.4_troll_regeneration",
+      "30.1.4_troll_regeneration_blocked"
+    ],
+    "30.2.1": [
+      "30.2.1_goblin_deploy_mountain_pass_only",
+      "30.2.1_goblin_one_per_hex",
+      "30.2.1_goblin_no_adjacency"
+    ],
+    "30.3.1": [
+      "30.3.1_dwarf_setup_locations"
+    ],
+    "30.3.2": [
+      "30.3.2_dwarf_locations_listed"
+    ],
+    "30.3.3": [
+      "30.3.3_dwarf_unity_common_cause"
+    ],
+    "31.1": [
+      "31.1_cities_vs_castles_distinction"
+    ],
+    "31.2.1": [
+      "31.2.1_city_without_castle_example"
+    ],
+    "31.2.2": [
+      "31.2.2_city_without_castle_no_siege"
+    ],
+    "31.3.1": [
+      "31.3.1_castle_identified_in_hexmap"
+    ],
+    "31.3.2": [
+      "31.3.2_castle_provides_intrinsic_defense"
+    ]
   }
 }


### PR DESCRIPTION
### Motivation
- Continue implementing the Conformance Suite plan by adding the advanced mechanics, events/outcomes, and special-rules test fixtures so the suite covers diplomacy, sieges, random events, death/capture, victory scoring, and kingdom-specific rules.
- Ensure traceability from `dr3_rules.json` to test IDs and update the coverage matrix so consumers can verify rule-to-test coverage.

### Description
- Added declarative JSON test fixtures for chunk 3 (advanced mechanics): `docs/conformance/chunk_3_advanced_mechanics/12_diplomacy.json`, `13_diplomacy_cards.json`, `14_personality_cards.json`, and `17_sieges.json` that cover diplomatic functions, cards, personality effects, and siege behavior.
- Added chunk 4 (events & outcomes) fixtures: `docs/conformance/chunk_4_events_outcomes/08_random_events.json`, `28_death_and_capture.json`, and `29_victory_conditions.json` that cover random events, monarch death/capture rules, and scoring.
- Added chunk 5 (special rules) fixtures: `docs/conformance/chunk_5_special_rules/30_special_kingdom_rules.json` and `31_cities_vs_castles.json`, and updated `docs/conformance/coverage_matrix.json` to include the new test IDs.
- Harmonized several test `id` values for consistent naming and ensured all new tests conform to the project `test_case` schema and coverage conventions.

### Testing
- Ran the suite validator `python scripts/validate_conformance_suite.py` which completed successfully and reported: `Validated 362 conformance tests.`
- The validator exit status was successful (0), indicating all new JSON fixtures pass the basic structural/coverage checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697617bd42fc8321adf381957559780c)