### PR TITLE
Add chunk 6 supporting and chunk 7 integration conformance fixtures

### DIFF
--- a/docs/conformance/chunk_6_supporting/09_mercenary_units.json
+++ b/docs/conformance/chunk_6_supporting/09_mercenary_units.json
@@ -1,0 +1,111 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "09_mercenary_units",
+  "tests": [
+    {
+      "id": "9.1_mercenaries_from_random_events",
+      "rule_ref": "9.1",
+      "description": "Mercenary combat units enter play through random events",
+      "input": {
+        "random_event": "mercenary_reinforcements"
+      },
+      "expected": {
+        "unit_source": "random_events_table",
+        "unit_class": "mercenary_combat"
+      }
+    },
+    {
+      "id": "9.2_placement_friendly_castle",
+      "rule_ref": "9.2",
+      "description": "Mercenaries may be placed at any friendly castle not under siege",
+      "input": {
+        "placement_hex": "Iron Keep",
+        "location_type": "castle",
+        "friendly": true,
+        "besieged": false
+      },
+      "expected": {
+        "placement_allowed": true
+      }
+    },
+    {
+      "id": "9.2_placement_besieged_castle_denied",
+      "rule_ref": "9.2",
+      "description": "Mercenaries may not be placed at besieged friendly castles",
+      "input": {
+        "placement_hex": "Iron Keep",
+        "location_type": "castle",
+        "friendly": true,
+        "besieged": true
+      },
+      "expected": {
+        "placement_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "9.3_stacking_with_friendly_units",
+      "rule_ref": "9.3",
+      "description": "Mercenary units may stack with any friendly units",
+      "input": {
+        "mercenary_unit": true,
+        "friendly_units_present": ["player_monarch", "allied_kingdom", "special_mercenary"]
+      },
+      "expected": {
+        "stacking_allowed": true
+      }
+    },
+    {
+      "id": "9.4.1_type_unavailable_defection",
+      "rule_ref": "9.4.1",
+      "description": "If remaining mercenary type cannot be deployed, desired type may defect",
+      "input": {
+        "requested_type": "army",
+        "remaining_pool_type": "fleet",
+        "can_deploy_remaining": false
+      },
+      "expected": {
+        "defection_allowed": true,
+        "defected_type": "army"
+      }
+    },
+    {
+      "id": "9.4.2_steal_and_redeploy",
+      "rule_ref": "9.4.2",
+      "description": "Stolen mercenary units are removed from opponent and deployed to a valid hex",
+      "input": {
+        "requested_type": "fleet",
+        "opponent_stack": ["mercenary_fleet"],
+        "valid_deployment_hexes": ["Freeport"]
+      },
+      "expected": {
+        "stolen_units": 1,
+        "deployment_hex": "Freeport"
+      }
+    },
+    {
+      "id": "9.4.3_pool_depleted_steal_any",
+      "rule_ref": "9.4.3",
+      "description": "When all mercenaries are in play, any type may be stolen",
+      "input": {
+        "mercenary_pool_empty": true
+      },
+      "expected": {
+        "allowed_types": "any"
+      }
+    },
+    {
+      "id": "9.4.4_transporting_fleet_protected",
+      "rule_ref": "9.4.4",
+      "description": "Mercenary fleets transporting enemy units cannot be stolen",
+      "input": {
+        "target_unit": "mercenary_fleet",
+        "transporting_enemy_units": true
+      },
+      "expected": {
+        "steal_allowed": false
+      },
+      "tags": ["negative"]
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/10_friendly_location.json
+++ b/docs/conformance/chunk_6_supporting/10_friendly_location.json
@@ -1,0 +1,59 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "10_friendly_location",
+  "tests": [
+    {
+      "id": "10.1.1_friendly_location_own_kingdom",
+      "rule_ref": "10.1.1",
+      "description": "Castle or port inside the player monarch's kingdom is friendly",
+      "input": {
+        "location_type": "castle",
+        "location_kingdom": "hothior",
+        "player_kingdom": "hothior"
+      },
+      "expected": {
+        "friendly": true
+      }
+    },
+    {
+      "id": "10.1.2_friendly_location_allied_kingdom",
+      "rule_ref": "10.1.2",
+      "description": "Castle or port inside an allied kingdom is friendly",
+      "input": {
+        "location_type": "port",
+        "location_kingdom": "mivior",
+        "allied_kingdoms": ["mivior"]
+      },
+      "expected": {
+        "friendly": true
+      }
+    },
+    {
+      "id": "10.1.3_plundered_castle_with_friendly_unit",
+      "rule_ref": "10.1.3",
+      "description": "Plundered castle or port occupied by a friendly combat unit is friendly",
+      "input": {
+        "location_type": "castle",
+        "plundered": true,
+        "friendly_combat_units_present": 1
+      },
+      "expected": {
+        "friendly": true
+      }
+    },
+    {
+      "id": "10.1.3_plundered_castle_without_friendly_unit",
+      "rule_ref": "10.1.3",
+      "description": "Plundered castle or port without friendly combat units is not friendly",
+      "input": {
+        "location_type": "castle",
+        "plundered": true,
+        "friendly_combat_units_present": 0
+      },
+      "expected": {
+        "friendly": false
+      },
+      "tags": ["negative"]
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/11_random_determination.json
+++ b/docs/conformance/chunk_6_supporting/11_random_determination.json
@@ -1,0 +1,47 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "11_random_determination",
+  "tests": [
+    {
+      "id": "11.1_random_die_faces_match_options",
+      "rule_ref": "11.1",
+      "description": "Random determination uses a die with faces equal to the number of options",
+      "input": {
+        "option_count": 4
+      },
+      "expected": {
+        "die_faces": 4
+      }
+    },
+    {
+      "id": "11.2.1_random_selection_three_allies",
+      "rule_ref": "11.2.1",
+      "description": "Selecting among three allies maps 1-2, 3-4, 5-6 on a d6",
+      "input": {
+        "options": ["ally_one", "ally_two", "ally_three"],
+        "die_type": "d6"
+      },
+      "expected": {
+        "roll_mapping": {
+          "1": "ally_one",
+          "2": "ally_one",
+          "3": "ally_two",
+          "4": "ally_two",
+          "5": "ally_three",
+          "6": "ally_three"
+        }
+      }
+    },
+    {
+      "id": "11.2.2_random_neutral_kingdoms",
+      "rule_ref": "11.2.2",
+      "description": "Randomly selecting from neutral kingdoms uses a die sized to the neutral count",
+      "input": {
+        "neutral_kingdom_count": 5
+      },
+      "expected": {
+        "die_faces": 5
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/16_allied_forces.json
+++ b/docs/conformance/chunk_6_supporting/16_allied_forces.json
@@ -1,0 +1,84 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "16_allied_forces",
+  "tests": [
+    {
+      "id": "16.1_allied_forces_moved_by_owner",
+      "rule_ref": "16.1",
+      "description": "Allied forces are moved by their owning player monarch",
+      "input": {
+        "allied_force_owner": "player_a",
+        "active_player": "player_a"
+      },
+      "expected": {
+        "movement_control": "player_a"
+      }
+    },
+    {
+      "id": "16.2_allied_stacking_restricted",
+      "rule_ref": "16.2",
+      "description": "Allied forces may not stack with forces of any other kingdom",
+      "input": {
+        "allied_kingdom": "mivior",
+        "other_kingdom": "hothior",
+        "end_turn_same_hex": true
+      },
+      "expected": {
+        "stacking_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "16.3_allied_forces_coordinate_actions",
+      "rule_ref": "16.3",
+      "description": "Allied forces may move, attack, and siege in conjunction with friendly forces",
+      "input": {
+        "allied_forces_present": true,
+        "friendly_forces_present": true
+      },
+      "expected": {
+        "coordination_allowed": true
+      }
+    },
+    {
+      "id": "16.4_allied_castle_entry_allowed",
+      "rule_ref": "16.4",
+      "description": "Combat units may enter and defend allied castles if unoccupied by allied combat units",
+      "input": {
+        "castle_owner": "mivior",
+        "entering_force": "hothior",
+        "allied_combat_units_present": 0
+      },
+      "expected": {
+        "entry_allowed": true,
+        "defense_allowed": true
+      }
+    },
+    {
+      "id": "16.4_allied_castle_entry_blocked",
+      "rule_ref": "16.4",
+      "description": "Allied castle entry is blocked when allied combat units already occupy the castle",
+      "input": {
+        "castle_owner": "mivior",
+        "entering_force": "hothior",
+        "allied_combat_units_present": 2
+      },
+      "expected": {
+        "entry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "16.5_mercenary_stacking_with_friendly",
+      "rule_ref": "16.5",
+      "description": "Mercenary units may stack with any friendly forces",
+      "input": {
+        "mercenary_unit": true,
+        "friendly_force": "allied_kingdom"
+      },
+      "expected": {
+        "stacking_allowed": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/20_ports.json
+++ b/docs/conformance/chunk_6_supporting/20_ports.json
@@ -1,0 +1,149 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "20_ports",
+  "tests": [
+    {
+      "id": "20.1_port_definition",
+      "rule_ref": "20.1",
+      "description": "Ports are seashore hexes enterable by vessels and land units",
+      "input": {
+        "hex_type": "seashore_port"
+      },
+      "expected": {
+        "enterable_by": ["land", "fleet"]
+      }
+    },
+    {
+      "id": "20.2.1_castle_port_anchor_icon",
+      "rule_ref": "20.2.1",
+      "description": "Castle-ports are castles with an anchor icon",
+      "input": {
+        "castle_has_anchor_icon": true
+      },
+      "expected": {
+        "is_castle_port": true
+      }
+    },
+    {
+      "id": "20.2.2_castle_port_applies_rules",
+      "rule_ref": "20.2.2",
+      "description": "Castle-ports apply both castle and port rules",
+      "input": {
+        "location_type": "castle_port"
+      },
+      "expected": {
+        "castle_rules_apply": true,
+        "port_rules_apply": true
+      }
+    },
+    {
+      "id": "20.2.3_plundered_castle_port_still_port",
+      "rule_ref": "20.2.3",
+      "description": "Plundered castle-ports still function as ports",
+      "input": {
+        "location_type": "castle_port",
+        "plundered": true
+      },
+      "expected": {
+        "functions_as_port": true
+      }
+    },
+    {
+      "id": "20.2.4_castle_port_storm_protection",
+      "rule_ref": "20.2.4",
+      "description": "Castle-ports protect unlimited fleets from storms",
+      "input": {
+        "location_type": "castle_port"
+      },
+      "expected": {
+        "storm_protection_fleet_limit": "unlimited"
+      }
+    },
+    {
+      "id": "20.2.5_castle_port_unoccupied_ownership",
+      "rule_ref": "20.2.5",
+      "description": "Unoccupied castle-ports are friendly to the original owner",
+      "input": {
+        "location_type": "castle_port",
+        "occupied": false
+      },
+      "expected": {
+        "friendly_to": "original_owner"
+      }
+    },
+    {
+      "id": "20.2.6_castle_port_occupied_ownership",
+      "rule_ref": "20.2.6",
+      "description": "Occupied castle-ports are friendly to the occupier",
+      "input": {
+        "location_type": "castle_port",
+        "occupied": true,
+        "occupier": "mivior"
+      },
+      "expected": {
+        "friendly_to": "mivior"
+      }
+    },
+    {
+      "id": "20.2.7_castle_port_examples",
+      "rule_ref": "20.2.7",
+      "description": "Groat is not a castle-port, Adeese is a castle-port",
+      "input": {
+        "locations": {
+          "Groat": {"castle": true, "anchor_icon": false},
+          "Adeese": {"castle": true, "anchor_icon": true}
+        }
+      },
+      "expected": {
+        "Groat": "castle_only",
+        "Adeese": "castle_port"
+      }
+    },
+    {
+      "id": "20.3.1_non_castle_port_examples",
+      "rule_ref": "20.3.1",
+      "description": "Examples of non-castle ports include Bartertown, Freeport, and Abandoned Village",
+      "input": {
+        "non_castle_ports": ["Bartertown", "Freeport", "Abandoned Village"]
+      },
+      "expected": {
+        "example_count": 3
+      }
+    },
+    {
+      "id": "20.3.2_non_castle_port_cost",
+      "rule_ref": "20.3.2",
+      "description": "Non-castle ports cost 1 movement point to enter",
+      "input": {
+        "location_type": "non_castle_port"
+      },
+      "expected": {
+        "movement_cost": 1
+      }
+    },
+    {
+      "id": "20.3.3_non_castle_port_storm_protection",
+      "rule_ref": "20.3.3",
+      "description": "Non-castle ports protect a single fleet from storms",
+      "input": {
+        "location_type": "non_castle_port"
+      },
+      "expected": {
+        "storm_protection_fleet_limit": 1
+      }
+    },
+    {
+      "id": "20.4_mercenary_fleet_deploy_non_castle_port",
+      "rule_ref": "20.4",
+      "description": "Mercenary fleets may deploy at friendly non-castle ports",
+      "input": {
+        "unit_type": "mercenary_fleet",
+        "location_type": "non_castle_port",
+        "friendly": true
+      },
+      "expected": {
+        "deployment_allowed": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/21_fleet_movement.json
+++ b/docs/conformance/chunk_6_supporting/21_fleet_movement.json
@@ -1,0 +1,78 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "21_fleet_movement",
+  "tests": [
+    {
+      "id": "21.1_fleet_terrain_types",
+      "rule_ref": "21.1",
+      "description": "Fleets may move through all-sea, seashore, and friendly ports",
+      "input": {
+        "allowed_terrain": ["all_sea", "seashore", "friendly_port"]
+      },
+      "expected": {
+        "movement_allowed": true
+      }
+    },
+    {
+      "id": "21.2_fleet_movement_cost",
+      "rule_ref": "21.2",
+      "description": "Fleet movement cost is 1 per hex",
+      "input": {
+        "terrain": "all_sea"
+      },
+      "expected": {
+        "movement_cost": 1
+      }
+    },
+    {
+      "id": "21.3.1_enemy_fleet_hex_blocked",
+      "rule_ref": "21.3.1",
+      "description": "Fleets cannot enter hexes occupied by enemy fleets",
+      "input": {
+        "destination_has_enemy_fleet": true
+      },
+      "expected": {
+        "entry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "21.3.2_allied_fleet_stacking_denied",
+      "rule_ref": "21.3.2",
+      "description": "Fleets cannot end movement in the same hex as an allied fleet",
+      "input": {
+        "destination_has_allied_fleet": true,
+        "ending_movement": true
+      },
+      "expected": {
+        "end_hex_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "21.3.3_seashore_enemy_land_pass_through",
+      "rule_ref": "21.3.3",
+      "description": "Fleets may pass through seashore hexes with enemy land units but may not end there",
+      "input": {
+        "seashore_hex": true,
+        "enemy_land_units_present": true
+      },
+      "expected": {
+        "may_pass_through": true,
+        "may_end_movement": false
+      }
+    },
+    {
+      "id": "21.3.4_lone_monarch_seashore_no_fate",
+      "rule_ref": "21.3.4",
+      "description": "No leader fate roll is required when passing through seashore with a lone monarch",
+      "input": {
+        "lone_monarch_on_seashore": true,
+        "fleet_passes_through": true
+      },
+      "expected": {
+        "fate_roll_required": false
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/22_sea_transport.json
+++ b/docs/conformance/chunk_6_supporting/22_sea_transport.json
@@ -1,0 +1,122 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "22_sea_transport",
+  "tests": [
+    {
+      "id": "22.1.1_transport_capacity_combat",
+      "rule_ref": "22.1.1",
+      "description": "Each fleet may transport one combat unit",
+      "input": {
+        "fleet_count": 2
+      },
+      "expected": {
+        "combat_unit_capacity": 2
+      }
+    },
+    {
+      "id": "22.1.2_transport_capacity_leaders",
+      "rule_ref": "22.1.2",
+      "description": "Fleets may transport unlimited leaders",
+      "input": {
+        "fleet_count": 1,
+        "leaders": 3
+      },
+      "expected": {
+        "leader_capacity": "unlimited"
+      }
+    },
+    {
+      "id": "22.1.3_transport_capacity_devices",
+      "rule_ref": "22.1.3",
+      "description": "Fleets may transport unlimited devices",
+      "input": {
+        "fleet_count": 1,
+        "devices": 2
+      },
+      "expected": {
+        "device_capacity": "unlimited"
+      }
+    },
+    {
+      "id": "22.2_embark_cost_zero",
+      "rule_ref": "22.2",
+      "description": "Embarking on a fleet costs 0 movement points",
+      "input": {
+        "embark_action": true
+      },
+      "expected": {
+        "movement_cost": 0
+      }
+    },
+    {
+      "id": "22.3_debark_cost_zero",
+      "rule_ref": "22.3",
+      "description": "Debarking from a fleet costs 0 movement points",
+      "input": {
+        "debark_action": true
+      },
+      "expected": {
+        "movement_cost": 0
+      }
+    },
+    {
+      "id": "22.4_debark_friendly_port",
+      "rule_ref": "22.4",
+      "description": "Units may debark at a friendly port",
+      "input": {
+        "destination_type": "friendly_port"
+      },
+      "expected": {
+        "debark_allowed": true
+      }
+    },
+    {
+      "id": "22.4_debark_seashore_no_mountains",
+      "rule_ref": "22.4",
+      "description": "Units may debark at seashore hexes without mountains",
+      "input": {
+        "destination_type": "seashore",
+        "terrain_features": ["clear"]
+      },
+      "expected": {
+        "debark_allowed": true
+      }
+    },
+    {
+      "id": "22.4_debark_seashore_mountains_denied",
+      "rule_ref": "22.4",
+      "description": "Units may not debark at seashore hexes with mountains",
+      "input": {
+        "destination_type": "seashore",
+        "terrain_features": ["mountain"]
+      },
+      "expected": {
+        "debark_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "22.5_transported_units_no_other_move",
+      "rule_ref": "22.5",
+      "description": "Transported units cannot otherwise move that turn",
+      "input": {
+        "unit_transported": true
+      },
+      "expected": {
+        "other_movement_allowed": false
+      }
+    },
+    {
+      "id": "22.6_fleet_continue_moving",
+      "rule_ref": "22.6",
+      "description": "Fleets may continue moving and transporting until movement points are spent",
+      "input": {
+        "fleet_movement_points": 3,
+        "actions": ["move", "embark", "move", "debark"]
+      },
+      "expected": {
+        "movement_points_remaining": 1
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/23_zones_of_control.json
+++ b/docs/conformance/chunk_6_supporting/23_zones_of_control.json
@@ -1,0 +1,40 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "23_zones_of_control",
+  "tests": [
+    {
+      "id": "23.1_zoc_not_used",
+      "rule_ref": "23.1",
+      "description": "Zones of control do not exist in the game",
+      "input": {
+        "unit_has_zoc": false
+      },
+      "expected": {
+        "zones_of_control": false
+      }
+    },
+    {
+      "id": "23.2_units_control_only_hex",
+      "rule_ref": "23.2",
+      "description": "Units control only the hex they occupy",
+      "input": {
+        "unit_hex": [10, 4]
+      },
+      "expected": {
+        "controlled_hexes": [[10, 4]]
+      }
+    },
+    {
+      "id": "23.3_adjacent_movement_no_penalty",
+      "rule_ref": "23.3",
+      "description": "Adjacent movement is not penalized by zones of control",
+      "input": {
+        "moving_adjacent_to_enemy": true
+      },
+      "expected": {
+        "movement_penalty": 0,
+        "movement_delay": false
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/24_stacking.json
+++ b/docs/conformance/chunk_6_supporting/24_stacking.json
@@ -1,0 +1,141 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "24_stacking",
+  "tests": [
+    {
+      "id": "24.1.1_same_kingdom_unlimited",
+      "rule_ref": "24.1.1",
+      "description": "Units of the same kingdom (plus mercenaries) may stack without limit",
+      "input": {
+        "kingdom": "hothior",
+        "unit_count": 12
+      },
+      "expected": {
+        "stack_limit": "unlimited"
+      }
+    },
+    {
+      "id": "24.1.2_same_kingdom_hex_sharing",
+      "rule_ref": "24.1.2",
+      "description": "Units of the same kingdom may occupy the same hex",
+      "input": {
+        "kingdom": "hothior",
+        "hex": [12, 6]
+      },
+      "expected": {
+        "hex_sharing_allowed": true
+      }
+    },
+    {
+      "id": "24.2.1_allied_pass_through",
+      "rule_ref": "24.2.1",
+      "description": "Allied kingdoms may pass through each other",
+      "input": {
+        "moving_kingdom": "hothior",
+        "hex_occupied_by": "mivior",
+        "passing_through": true
+      },
+      "expected": {
+        "pass_through_allowed": true
+      }
+    },
+    {
+      "id": "24.2.2_allied_end_turn_denied",
+      "rule_ref": "24.2.2",
+      "description": "Allied kingdoms may not end the turn in the same hex",
+      "input": {
+        "moving_kingdom": "hothior",
+        "hex_occupied_by": "mivior",
+        "ending_turn": true
+      },
+      "expected": {
+        "end_turn_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "24.3.1_mercenary_stack_with_friendly",
+      "rule_ref": "24.3.1",
+      "description": "Mercenaries may stack with any friendly units",
+      "input": {
+        "mercenary_unit": true,
+        "friendly_unit": "allied_kingdom"
+      },
+      "expected": {
+        "stacking_allowed": true
+      }
+    },
+    {
+      "id": "24.3.2_mercenary_move_between_stacks",
+      "rule_ref": "24.3.2",
+      "description": "Mercenaries may move between friendly stacks without penalty",
+      "input": {
+        "mercenary_unit": true,
+        "moving_between_stacks": true
+      },
+      "expected": {
+        "movement_penalty": 0
+      }
+    },
+    {
+      "id": "24.4.1_fleet_stacking_same_rules",
+      "rule_ref": "24.4.1",
+      "description": "Fleet stacking follows the same rules as land units",
+      "input": {
+        "fleet_units": true
+      },
+      "expected": {
+        "stacking_rules": "same_as_land"
+      }
+    },
+    {
+      "id": "24.5.1_allied_castle_entry_condition",
+      "rule_ref": "24.5.1",
+      "description": "Allied castle entry allowed only if no allied combat units occupy the castle",
+      "input": {
+        "allied_castle": true,
+        "allied_combat_units_present": 0
+      },
+      "expected": {
+        "entry_allowed": true
+      }
+    },
+    {
+      "id": "24.5.2_allied_castle_entry_defense",
+      "rule_ref": "24.5.2",
+      "description": "Units may enter and defend allied castles when allowed",
+      "input": {
+        "allied_castle": true,
+        "entry_allowed": true
+      },
+      "expected": {
+        "defense_allowed": true
+      }
+    },
+    {
+      "id": "24.5.3_allied_castle_no_stacking",
+      "rule_ref": "24.5.3",
+      "description": "Units may not stack with allied units inside allied castles",
+      "input": {
+        "allied_castle": true,
+        "allied_units_present": true
+      },
+      "expected": {
+        "stacking_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "24.6_stack_examination_allowed",
+      "rule_ref": "24.6",
+      "description": "Any player may examine opponent stacks at any time",
+      "input": {
+        "requesting_player": "player_a",
+        "target_player": "player_b"
+      },
+      "expected": {
+        "inspection_allowed": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_6_supporting/27_leader_adrift.json
+++ b/docs/conformance/chunk_6_supporting/27_leader_adrift.json
@@ -1,0 +1,136 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "27_leader_adrift",
+  "tests": [
+    {
+      "id": "27.1_leader_adrift_trigger",
+      "rule_ref": "27.1",
+      "description": "Leader without a fleet on open sea is adrift",
+      "input": {
+        "leader_on_open_sea": true,
+        "fleet_present": false
+      },
+      "expected": {
+        "leader_adrift": true
+      }
+    },
+    {
+      "id": "27.2.1_adrift_fate_roll_death",
+      "rule_ref": "27.2.1",
+      "description": "Adrift fate roll of 1 results in death",
+      "input": {
+        "fate_roll": 1
+      },
+      "expected": {
+        "result": "death"
+      }
+    },
+    {
+      "id": "27.2.2_adrift_fate_roll_capture",
+      "rule_ref": "27.2.2",
+      "description": "Adrift fate roll of 6 results in capture",
+      "input": {
+        "fate_roll": 6
+      },
+      "expected": {
+        "result": "capture"
+      }
+    },
+    {
+      "id": "27.2.3_adrift_fate_roll_no_effect",
+      "rule_ref": "27.2.3",
+      "description": "Adrift fate rolls of 2-5 have no effect",
+      "input": {
+        "fate_roll": 3
+      },
+      "expected": {
+        "result": "no_effect"
+      }
+    },
+    {
+      "id": "27.3_no_enemy_fleet_isle_of_fright",
+      "rule_ref": "27.3",
+      "description": "If no enemy fleet is present, the leader is placed on Isle of Fright",
+      "input": {
+        "enemy_fleet_present": false
+      },
+      "expected": {
+        "placement": "isle_of_fright"
+      }
+    },
+    {
+      "id": "27.4_isle_of_fright_penalty",
+      "rule_ref": "27.4",
+      "description": "While on Isle of Fright, the monarch's troops suffer -1 on combat and siege rolls",
+      "input": {
+        "monarch_on_isle_of_fright": true
+      },
+      "expected": {
+        "combat_roll_modifier": -1,
+        "siege_roll_modifier": -1
+      }
+    },
+    {
+      "id": "27.5_rescue_by_friendly_fleet",
+      "rule_ref": "27.5",
+      "description": "A friendly fleet may rescue the leader by moving into the hex",
+      "input": {
+        "friendly_fleet_enters_hex": true
+      },
+      "expected": {
+        "rescue_successful": true
+      }
+    },
+    {
+      "id": "27.6_enemy_capture_not_possible",
+      "rule_ref": "27.6",
+      "description": "Enemy capture is not possible while on Isle of Fright",
+      "input": {
+        "monarch_on_isle_of_fright": true,
+        "enemy_fleet_present": true
+      },
+      "expected": {
+        "capture_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "27.7_no_combat_unit_unload",
+      "rule_ref": "27.7",
+      "description": "Combat units cannot unload on Isle of Fright",
+      "input": {
+        "destination": "isle_of_fright",
+        "unit_type": "army"
+      },
+      "expected": {
+        "unload_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "27.8_fleet_entry_rescue_only",
+      "rule_ref": "27.8",
+      "description": "Fleets may enter Isle of Fright only to rescue the leader",
+      "input": {
+        "destination": "isle_of_fright",
+        "fleet_entry_reason": "combat"
+      },
+      "expected": {
+        "entry_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "27.9_diplomacy_allowed_with_castaway",
+      "rule_ref": "27.9",
+      "description": "Ambassadors may conduct diplomacy with a castaway monarch",
+      "input": {
+        "castaway_monarch": true,
+        "ambassador_action": "diplomacy"
+      },
+      "expected": {
+        "diplomacy_allowed": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_7_integration/rule_interactions.json
+++ b/docs/conformance/chunk_7_integration/rule_interactions.json
@@ -1,0 +1,71 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "rule_interactions",
+  "tests": [
+    {
+      "id": "22.5_transported_units_eliminated_in_combat",
+      "rule_refs": ["22.5", "25.6.1"],
+      "description": "Transported combat units do not move independently and are eliminated if their transport is destroyed",
+      "input": {
+        "transported_unit": "army",
+        "fleet_in_combat": true,
+        "fleet_destroyed": true
+      },
+      "expected": {
+        "transported_unit_movement_allowed": false,
+        "transported_unit_survives": false
+      }
+    },
+    {
+      "id": "17.12.1_relief_force_advances_two",
+      "rule_refs": ["17.12.1", "25.13.4"],
+      "description": "Relief force procedure allows advancing two hexes after combat",
+      "input": {
+        "relief_force_declared": true,
+        "combat_won": true
+      },
+      "expected": {
+        "advance_hexes": 2
+      }
+    },
+    {
+      "id": "12.1.1_diplomacy_with_captured_monarch",
+      "rule_refs": ["12.1.1", "28.3.4"],
+      "description": "Captured monarchs remain valid diplomacy targets but cannot act while imprisoned",
+      "input": {
+        "captured_monarch": true,
+        "diplomacy_attempt": true
+      },
+      "expected": {
+        "diplomacy_allowed": true,
+        "captured_monarch_actions": "none"
+      }
+    },
+    {
+      "id": "12.3.2_deactivation_breaks_siege_coordination",
+      "rule_refs": ["12.3.2", "17.6.1"],
+      "description": "Deactivation of an allied monarch halts their participation in an ongoing siege",
+      "input": {
+        "siege_active": true,
+        "ally_deactivated": true
+      },
+      "expected": {
+        "ally_participation": "removed",
+        "siege_status": "continues_without_ally"
+      }
+    },
+    {
+      "id": "8.3.7_random_event_during_siege",
+      "rule_refs": ["8.3.7", "17.8.1"],
+      "description": "Replacement events resolve immediately even if a siege will resolve later in the siege phase",
+      "input": {
+        "random_event": "replacements",
+        "siege_pending": true
+      },
+      "expected": {
+        "replacement_resolved": true,
+        "siege_resolution_phase": "siege_phase"
+      }
+    }
+  ]
+}

--- a/docs/conformance/coverage_matrix.json
+++ b/docs/conformance/coverage_matrix.json
@@ -158,7 +158,8 @@
       "8.3.6_regular_limit_respected"
     ],
     "8.3.7": [
-      "8.3.7_immediate_action_for_replacements"
+      "8.3.7_immediate_action_for_replacements",
+      "8.3.7_random_event_during_siege"
     ],
     "8.3.8": [
       "8.3.8_impossible_event_no_event"
@@ -166,8 +167,50 @@
     "8.3.9": [
       "8.3.9_no_transfer_between_players"
     ],
+    "9.1": [
+      "9.1_mercenaries_from_random_events"
+    ],
+    "9.2": [
+      "9.2_placement_friendly_castle",
+      "9.2_placement_besieged_castle_denied"
+    ],
+    "9.3": [
+      "9.3_stacking_with_friendly_units"
+    ],
+    "9.4.1": [
+      "9.4.1_type_unavailable_defection"
+    ],
+    "9.4.2": [
+      "9.4.2_steal_and_redeploy"
+    ],
+    "9.4.3": [
+      "9.4.3_pool_depleted_steal_any"
+    ],
+    "9.4.4": [
+      "9.4.4_transporting_fleet_protected"
+    ],
+    "10.1.1": [
+      "10.1.1_friendly_location_own_kingdom"
+    ],
+    "10.1.2": [
+      "10.1.2_friendly_location_allied_kingdom"
+    ],
+    "10.1.3": [
+      "10.1.3_plundered_castle_with_friendly_unit",
+      "10.1.3_plundered_castle_without_friendly_unit"
+    ],
+    "11.1": [
+      "11.1_random_die_faces_match_options"
+    ],
+    "11.2.1": [
+      "11.2.1_random_selection_three_allies"
+    ],
+    "11.2.2": [
+      "11.2.2_random_neutral_kingdoms"
+    ],
     "12.1.1": [
-      "12.1.1_diplomacy_only_between"
+      "12.1.1_diplomacy_only_between",
+      "12.1.1_diplomacy_with_captured_monarch"
     ],
     "12.1.2": [
       "12.1.2_player_alliances_not_binding"
@@ -199,7 +242,8 @@
     ],
     "12.3.2": [
       "12.3.2_deactivate_threshold",
-      "12.3.2_deactivate_effects"
+      "12.3.2_deactivate_effects",
+      "12.3.2_deactivation_breaks_siege_coordination"
     ],
     "12.3.3": [
       "12.3.3_assassination_limit_once",
@@ -296,6 +340,22 @@
     "14.4": [
       "14.4_personality_effects_apply"
     ],
+    "16.1": [
+      "16.1_allied_forces_moved_by_owner"
+    ],
+    "16.2": [
+      "16.2_allied_stacking_restricted"
+    ],
+    "16.3": [
+      "16.3_allied_forces_coordinate_actions"
+    ],
+    "16.4": [
+      "16.4_allied_castle_entry_allowed",
+      "16.4_allied_castle_entry_blocked"
+    ],
+    "16.5": [
+      "16.5_mercenary_stacking_with_friendly"
+    ],
     "17.1.1": [
       "17.1.1_castle_surrounded_required"
     ],
@@ -354,7 +414,8 @@
       "17.5.4_plundered_castle_no_defense"
     ],
     "17.6.1": [
-      "17.6.1_siege_declared_when_conditions_met"
+      "17.6.1_siege_declared_when_conditions_met",
+      "12.3.2_deactivation_breaks_siege_coordination"
     ],
     "17.6.2": [
       "17.6.2_any_player_may_declare"
@@ -376,7 +437,8 @@
       "17.7.3_attack_from_siege_breaks_siege"
     ],
     "17.8.1": [
-      "17.8.1_resolution_in_siege_phase"
+      "17.8.1_resolution_in_siege_phase",
+      "8.3.7_random_event_during_siege"
     ],
     "17.8.2": [
       "17.8.2_siege_roll_single_die"
@@ -439,7 +501,8 @@
       "17.11.5_seaborne_units_count_in_siege"
     ],
     "17.12.1": [
-      "17.12.1_relief_force_procedure"
+      "17.12.1_relief_force_procedure",
+      "17.12.1_relief_force_advances_two"
     ],
     "17.12.2": [
       "17.12.2_relief_force_two_hex_advance"
@@ -638,6 +701,129 @@
     "19.17.2": [
       "19.17.2_forested_mountain_cost"
     ],
+    "20.1": [
+      "20.1_port_definition"
+    ],
+    "20.2.1": [
+      "20.2.1_castle_port_anchor_icon"
+    ],
+    "20.2.2": [
+      "20.2.2_castle_port_applies_rules"
+    ],
+    "20.2.3": [
+      "20.2.3_plundered_castle_port_still_port"
+    ],
+    "20.2.4": [
+      "20.2.4_castle_port_storm_protection"
+    ],
+    "20.2.5": [
+      "20.2.5_castle_port_unoccupied_ownership"
+    ],
+    "20.2.6": [
+      "20.2.6_castle_port_occupied_ownership"
+    ],
+    "20.2.7": [
+      "20.2.7_castle_port_examples"
+    ],
+    "20.3.1": [
+      "20.3.1_non_castle_port_examples"
+    ],
+    "20.3.2": [
+      "20.3.2_non_castle_port_cost"
+    ],
+    "20.3.3": [
+      "20.3.3_non_castle_port_storm_protection"
+    ],
+    "20.4": [
+      "20.4_mercenary_fleet_deploy_non_castle_port"
+    ],
+    "21.1": [
+      "21.1_fleet_terrain_types"
+    ],
+    "21.2": [
+      "21.2_fleet_movement_cost"
+    ],
+    "21.3.1": [
+      "21.3.1_enemy_fleet_hex_blocked"
+    ],
+    "21.3.2": [
+      "21.3.2_allied_fleet_stacking_denied"
+    ],
+    "21.3.3": [
+      "21.3.3_seashore_enemy_land_pass_through"
+    ],
+    "21.3.4": [
+      "21.3.4_lone_monarch_seashore_no_fate"
+    ],
+    "22.1.1": [
+      "22.1.1_transport_capacity_combat"
+    ],
+    "22.1.2": [
+      "22.1.2_transport_capacity_leaders"
+    ],
+    "22.1.3": [
+      "22.1.3_transport_capacity_devices"
+    ],
+    "22.2": [
+      "22.2_embark_cost_zero"
+    ],
+    "22.3": [
+      "22.3_debark_cost_zero"
+    ],
+    "22.4": [
+      "22.4_debark_friendly_port",
+      "22.4_debark_seashore_no_mountains",
+      "22.4_debark_seashore_mountains_denied"
+    ],
+    "22.5": [
+      "22.5_transported_units_no_other_move",
+      "22.5_transported_units_eliminated_in_combat"
+    ],
+    "22.6": [
+      "22.6_fleet_continue_moving"
+    ],
+    "23.1": [
+      "23.1_zoc_not_used"
+    ],
+    "23.2": [
+      "23.2_units_control_only_hex"
+    ],
+    "23.3": [
+      "23.3_adjacent_movement_no_penalty"
+    ],
+    "24.1.1": [
+      "24.1.1_same_kingdom_unlimited"
+    ],
+    "24.1.2": [
+      "24.1.2_same_kingdom_hex_sharing"
+    ],
+    "24.2.1": [
+      "24.2.1_allied_pass_through"
+    ],
+    "24.2.2": [
+      "24.2.2_allied_end_turn_denied"
+    ],
+    "24.3.1": [
+      "24.3.1_mercenary_stack_with_friendly"
+    ],
+    "24.3.2": [
+      "24.3.2_mercenary_move_between_stacks"
+    ],
+    "24.4.1": [
+      "24.4.1_fleet_stacking_same_rules"
+    ],
+    "24.5.1": [
+      "24.5.1_allied_castle_entry_condition"
+    ],
+    "24.5.2": [
+      "24.5.2_allied_castle_entry_defense"
+    ],
+    "24.5.3": [
+      "24.5.3_allied_castle_no_stacking"
+    ],
+    "24.6": [
+      "24.6_stack_examination_allowed"
+    ],
     "25.1.1": [
       "25.1.1_only_active_player_attacks"
     ],
@@ -764,7 +950,8 @@
       "25.13.3_advance_one_hex_only"
     ],
     "25.13.4": [
-      "25.13.4_siege_relief_advance_two"
+      "25.13.4_siege_relief_advance_two",
+      "17.12.1_relief_force_advances_two"
     ],
     "26.1": [
       "26.1.1_monarchs_are_leaders"
@@ -828,6 +1015,39 @@
     "26.7": [
       "26.7.1_lone_leader_cannot_be_attacked"
     ],
+    "27.1": [
+      "27.1_leader_adrift_trigger"
+    ],
+    "27.2.1": [
+      "27.2.1_adrift_fate_roll_death"
+    ],
+    "27.2.2": [
+      "27.2.2_adrift_fate_roll_capture"
+    ],
+    "27.2.3": [
+      "27.2.3_adrift_fate_roll_no_effect"
+    ],
+    "27.3": [
+      "27.3_no_enemy_fleet_isle_of_fright"
+    ],
+    "27.4": [
+      "27.4_isle_of_fright_penalty"
+    ],
+    "27.5": [
+      "27.5_rescue_by_friendly_fleet"
+    ],
+    "27.6": [
+      "27.6_enemy_capture_not_possible"
+    ],
+    "27.7": [
+      "27.7_no_combat_unit_unload"
+    ],
+    "27.8": [
+      "27.8_fleet_entry_rescue_only"
+    ],
+    "27.9": [
+      "27.9_diplomacy_allowed_with_castaway"
+    ],
     "28.1.1": [
       "28.1.1_non_player_death_confusion"
     ],
@@ -877,7 +1097,8 @@
       "28.3.3_capture_awards_points"
     ],
     "28.3.4": [
-      "28.3.4_prisoner_cannot_act"
+      "28.3.4_prisoner_cannot_act",
+      "12.1.1_diplomacy_with_captured_monarch"
     ],
     "28.3.5": [
       "28.3.5_release_conditions"


### PR DESCRIPTION
### Motivation
- Implement the next delivery chunk(s) of the Conformance Suite plan by adding the supporting-rule fixtures (Chunk 6) and initial multi-rule integration scenarios (Chunk 7). 
- Provide machine-readable, declarative test data for smaller supporting rules that feed into core mechanics (mercenaries, friendly locations, ports/fleets/transport, stacking, allied forces, leader adrift, randomness). 
- Update the coverage matrix so new fixtures map back to their rule references for traceability and CI coverage tracking. 

### Description
- Added Chunk 6 supporting fixtures under `docs/conformance/chunk_6_supporting/` for rules: `09_mercenary_units.json`, `10_friendly_location.json`, `11_random_determination.json`, `16_allied_forces.json`, `20_ports.json`, `21_fleet_movement.json`, `22_sea_transport.json`, `23_zones_of_control.json`, `24_stacking.json`, and `27_leader_adrift.json`.
- Added Chunk 7 integration scenarios in `docs/conformance/chunk_7_integration/rule_interactions.json` to capture multi-rule interactions (transported units, relief advances, diplomacy with captured monarchs, deactivation vs siege coordination, random events during siege).
- Updated `docs/conformance/coverage_matrix.json` to map all newly added test IDs to their corresponding rule references for coverage tracking.
- Committed the data files to the repository (data-only change). 

### Testing
- No automated tests were executed as part of this change because these are specification/test-fixture (data-only) files; changes were validated by file creation and committing to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976478ff37c83218736b7af8d839a11)