### PR TITLE
Improve conformance suite: schema, coverage, validation, CI

### DIFF
--- a/.github/workflows/conformance-validation.yml
+++ b/.github/workflows/conformance-validation.yml
@@ -1,0 +1,29 @@
+name: Conformance Suite Validation
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'docs/conformance/**'
+      - 'scripts/validate_conformance_suite.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'docs/conformance/**'
+      - 'scripts/validate_conformance_suite.py'
+
+jobs:
+  validate:
+    name: Validate Conformance Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate conformance tests and coverage matrix
+        run: python3 scripts/validate_conformance_suite.py

--- a/.github/workflows/conformance-validation.yml
+++ b/.github/workflows/conformance-validation.yml
@@ -12,6 +12,9 @@ on:
       - 'docs/conformance/**'
       - 'scripts/validate_conformance_suite.py'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Conformance Suite

--- a/docs/conformance/chunk_6_supporting/15_activated_violated_kingdom.json
+++ b/docs/conformance/chunk_6_supporting/15_activated_violated_kingdom.json
@@ -1,0 +1,106 @@
+{
+  "suite_version": "1.0.0",
+  "rule_section": "15_activated_violated_kingdom",
+  "tests": [
+    {
+      "id": "15.1_placement_hex_occupied_triggers_activation",
+      "rule_ref": "15.1",
+      "description": "A neutral kingdom's placement hexes being occupied by enemy combat units triggers the activation procedure",
+      "input": {
+        "kingdom": "neuth",
+        "kingdom_status": "neutral",
+        "placement_hex_occupied_by_enemy": true,
+        "occupying_unit_type": "regular_army"
+      },
+      "expected": {
+        "activation_triggered": true
+      }
+    },
+    {
+      "id": "15.1_non_combat_unit_no_trigger",
+      "rule_ref": "15.1",
+      "description": "A non-combat unit (ambassador) occupying a placement hex does not trigger kingdom activation",
+      "input": {
+        "kingdom": "neuth",
+        "kingdom_status": "neutral",
+        "placement_hex_occupied_by_enemy": true,
+        "occupying_unit_type": "ambassador"
+      },
+      "expected": {
+        "activation_triggered": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "15.2_ambassador_placed_anywhere_in_kingdom",
+      "rule_ref": "15.2",
+      "description": "When a kingdom is activated via violation, the ambassador may be placed anywhere in the kingdom territory",
+      "input": {
+        "activation_type": "violation",
+        "kingdom": "neuth",
+        "ambassador_placement": "any_kingdom_hex"
+      },
+      "expected": {
+        "ambassador_placement_valid": true
+      },
+      "notes": "Unlike normal activation which requires placement at the royal castle"
+    },
+    {
+      "id": "15.3_units_placed_normally_and_adjacent",
+      "rule_ref": "15.3",
+      "description": "Units are placed at normal starting locations and/or adjacent to occupied placement hexes",
+      "input": {
+        "kingdom": "neuth",
+        "occupied_placement_hexes": [[8, 10]],
+        "normal_placement_hexes_available": true
+      },
+      "expected": {
+        "placement_at_normal_locations": true,
+        "placement_adjacent_to_occupied": true
+      }
+    },
+    {
+      "id": "15.4.1_siege_on_neutral_triggers_alliance",
+      "rule_ref": "15.4",
+      "description": "Siege declared on a neutral kingdom's castle causes the kingdom to immediately join an alliance with another player monarch",
+      "input": {
+        "kingdom": "ghem",
+        "kingdom_status": "neutral",
+        "siege_declared_on_castle": true
+      },
+      "expected": {
+        "kingdom_joins_alliance": true,
+        "alliance_partner": "another_player_monarch"
+      }
+    },
+    {
+      "id": "15.4_alliance_partner_random",
+      "rule_ref": "15.4",
+      "description": "The alliance partner for a violated kingdom is determined randomly from eligible player monarchs",
+      "input": {
+        "kingdom": "ghem",
+        "siege_declared_on_castle": true,
+        "eligible_player_monarchs": ["player_a", "player_b"],
+        "violating_player": "player_a"
+      },
+      "expected": {
+        "alliance_determination": "random",
+        "violating_player_eligible": false
+      },
+      "notes": "The player who caused the violation cannot be the alliance partner"
+    },
+    {
+      "id": "15.4_siege_conditions_refigured",
+      "rule_ref": "15.4",
+      "description": "After a violated kingdom is activated and forces placed, siege conditions must be recalculated",
+      "input": {
+        "siege_active": true,
+        "kingdom_activated_via_violation": true,
+        "new_forces_placed": true
+      },
+      "expected": {
+        "siege_conditions_refigured": true
+      }
+    }
+  ]
+}

--- a/docs/conformance/chunk_7_integration/rule_interactions.json
+++ b/docs/conformance/chunk_7_integration/rule_interactions.json
@@ -66,6 +66,239 @@
         "replacement_resolved": true,
         "siege_resolution_phase": "siege_phase"
       }
+    },
+    {
+      "id": "26.3_leader_terrain_no_transfer_to_stack",
+      "rule_refs": ["26.3.2", "26.3.6"],
+      "description": "Stack uses leader's movement allowance but unit terrain bonuses do not transfer to the leader or other units",
+      "input": {
+        "leader_has_mountain_symbol": false,
+        "stack_unit_has_mountain_symbol": true,
+        "terrain": "mountain"
+      },
+      "expected": {
+        "stack_uses_leader_ma": true,
+        "stack_must_stop_in_mountain": true
+      },
+      "notes": "Unit terrain bonuses are per-unit, not shared via leader"
+    },
+    {
+      "id": "25.2_retreat_into_allied_hex_stacking",
+      "rule_refs": ["25.2.4", "24.2.2"],
+      "description": "Units retreating before combat cannot end in a hex with units from a different allied kingdom",
+      "input": {
+        "retreating_faction": "hothior",
+        "retreat_hex_occupant_faction": "mivior",
+        "factions_allied": true,
+        "other_adjacent_hexes_available": true
+      },
+      "expected": {
+        "retreat_to_allied_hex_allowed": false,
+        "must_retreat_to_empty_or_own_hex": true
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "8.2_untimely_death_during_siege",
+      "rule_refs": ["8.2.1", "28.1.1", "17.6.1"],
+      "description": "Untimely death of a besieging allied monarch triggers confusion: their forces cannot continue siege participation",
+      "input": {
+        "random_event": "untimely_death",
+        "dead_monarch": "non_player_allied",
+        "monarch_forces_besieging": true
+      },
+      "expected": {
+        "kingdom_enters_confusion": true,
+        "regulars_defend_only": true,
+        "siege_contribution_removed": true,
+        "siege_conditions_refigured": true
+      }
+    },
+    {
+      "id": "22.4_debark_mountain_seashore_denied",
+      "rule_refs": ["22.4", "19.6.1"],
+      "description": "Units cannot debark at a seashore hex that is also a mountain hex",
+      "input": {
+        "fleet_hex": "seashore",
+        "debark_target_terrain": "mountain_seashore",
+        "debark_target_has_port": false
+      },
+      "expected": {
+        "debark_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "26.6_leader_fate_fleet_transport_destroyed",
+      "rule_refs": ["26.6.1", "22.5"],
+      "description": "Leader aboard a fleet that is destroyed in combat triggers a fate roll; transported army is eliminated",
+      "input": {
+        "leader_transported": true,
+        "army_transported": true,
+        "fleet_destroyed_in_combat": true,
+        "fate_roll": 3
+      },
+      "expected": {
+        "fate_roll_triggered": true,
+        "army_eliminated": true,
+        "leader_fate_result": "no_effect"
+      }
+    },
+    {
+      "id": "18.3_activated_kingdom_no_move_or_attack",
+      "rule_refs": ["18.3.2", "25.7.2"],
+      "description": "Units of a just-activated kingdom cannot move or initiate attacks on the turn of activation",
+      "input": {
+        "kingdom_activated_this_turn": true,
+        "unit_attempts_move": true,
+        "unit_attempts_attack": true
+      },
+      "expected": {
+        "move_allowed": false,
+        "attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.13_forced_peace_plunder_permanent",
+      "rule_refs": ["17.13.9", "17.13.12"],
+      "description": "When forced peace deactivates a kingdom, plundered castles remain plundered even after the kingdom becomes available again",
+      "input": {
+        "forced_peace_applied": true,
+        "castle_was_plundered": true,
+        "forced_peace_expired": true
+      },
+      "expected": {
+        "castle_still_plundered": true,
+        "kingdom_available_for_diplomacy": true
+      }
+    },
+    {
+      "id": "30.1_troll_regeneration_blocked_by_enemy",
+      "rule_refs": ["30.1.4", "18.5.1"],
+      "description": "Troll regeneration is blocked if the placement hex is occupied by enemy combat units",
+      "input": {
+        "faction": "trolls",
+        "eliminated_regular_count": 1,
+        "placement_hex_enemy_occupied": true
+      },
+      "expected": {
+        "regeneration_occurs": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "25.13_advance_into_castle_siege_break",
+      "rule_refs": ["25.13.1", "17.7.3"],
+      "description": "Units inside a besieged castle attack out during combat phase; if all besiegers eliminated, units may advance one hex and siege breaks",
+      "input": {
+        "units_inside_castle": 3,
+        "besieging_units_in_target_hex": 2,
+        "combat_result": "all_defenders_eliminated",
+        "attack_phase": "combat"
+      },
+      "expected": {
+        "advance_allowed": true,
+        "advance_limit_hexes": 1,
+        "siege_broken": true
+      }
+    },
+    {
+      "id": "12.3_assassination_kills_ambassador",
+      "rule_refs": ["12.3.3", "12.4.1"],
+      "description": "Failed assassination attempt permanently banishes the ambassador; ambassador treated as dead for recovery purposes",
+      "input": {
+        "assassination_attempted": true,
+        "attacker_roll": 2,
+        "defender_roll": 5
+      },
+      "expected": {
+        "assassination_success": false,
+        "ambassador_status": "permanently_banished",
+        "ambassador_recovery_possible": false
+      }
+    },
+    {
+      "id": "28.2_player_death_deactivates_allies",
+      "rule_refs": ["28.2.1", "28.2.2", "12.3.2"],
+      "description": "Player monarch death eliminates the player and immediately deactivates all allied kingdoms",
+      "input": {
+        "player_monarch_killed": true,
+        "allied_kingdoms": ["neuth", "mivior"]
+      },
+      "expected": {
+        "player_eliminated": true,
+        "allied_kingdoms_deactivated": true,
+        "allied_forces_removed_after_combat": true
+      }
+    },
+    {
+      "id": "6.2_mountain_symbol_leader_stack_movement",
+      "rule_refs": ["6.2.2", "26.3.2"],
+      "description": "Leader with mountain symbol moves a stack through mountains without stopping; stack still pays 3 MP per mountain hex",
+      "input": {
+        "leader_has_mountain_symbol": true,
+        "stack_size": 3,
+        "terrain": "mountain",
+        "leader_movement_allowance": 8
+      },
+      "expected": {
+        "must_stop": false,
+        "movement_cost": 3,
+        "stack_uses_leader_ma": true
+      },
+      "notes": "Mountain symbol on leader allows the stack to pass through without stopping"
+    },
+    {
+      "id": "17.7_leave_siege_full_movement",
+      "rule_refs": ["17.7.2", "18.1.3"],
+      "description": "Units leaving a besieged castle after attacking besiegers get full movement allowance but cannot attack further",
+      "input": {
+        "units_in_castle": 4,
+        "attack_on_besiegers_resolved": true,
+        "combat_result": "attacker_wins"
+      },
+      "expected": {
+        "survivors_may_leave": true,
+        "movement_allowance": "full",
+        "further_attacks_allowed": false
+      }
+    },
+    {
+      "id": "28.1_confusion_border_violation_crowns_new_monarch",
+      "rule_refs": ["28.1.5", "15.1"],
+      "description": "Entering a confused kingdom's territory triggers immediate crowning of a new monarch and diplomatic penalty",
+      "input": {
+        "target_kingdom_in_confusion": true,
+        "enemy_enters_kingdom_hex": true
+      },
+      "expected": {
+        "diplomatic_penalty_applies": true,
+        "new_monarch_crowned_immediately": true,
+        "kingdom_available_immediately": true,
+        "confusion_ends": true
+      }
+    },
+    {
+      "id": "25.9_multi_hex_allied_combined_attack",
+      "rule_refs": ["25.9.1", "25.9.2"],
+      "description": "Units from multiple hexes and different allied kingdoms may combine strength when attacking the same defender hex",
+      "input": {
+        "attacker_hexes": [
+          { "hex": [10, 5], "units": 3, "faction": "hothior" },
+          { "hex": [11, 5], "units": 2, "faction": "mivior" }
+        ],
+        "defender_hex": [10, 6],
+        "defender_units": 4,
+        "factions_allied": true
+      },
+      "expected": {
+        "combined_attack_allowed": true,
+        "total_attacker_strength": 5,
+        "combat_modifier_applies_to": "attacker",
+        "combat_modifier": 0
+      },
+      "notes": "5/4 = 1.25, drop fraction = 1, minus 1 = 0 modifier"
     }
   ]
 }

--- a/docs/conformance/chunk_7_integration/rule_interactions.json
+++ b/docs/conformance/chunk_7_integration/rule_interactions.json
@@ -116,8 +116,8 @@
     },
     {
       "id": "22.4_debark_mountain_seashore_denied",
-      "rule_refs": ["22.4", "19.6.1"],
-      "description": "Units cannot debark at a seashore hex that is also a mountain hex",
+      "rule_refs": ["22.4", "19.6.2"],
+      "description": "Units cannot debark at a seashore hex that is also a mountain hex; mountain stopping rules compound the restriction",
       "input": {
         "fleet_hex": "seashore",
         "debark_target_terrain": "mountain_seashore",
@@ -126,7 +126,8 @@
       "expected": {
         "debark_allowed": false
       },
-      "tags": ["negative"]
+      "tags": ["negative"],
+      "notes": "Rule 22.4 explicitly excludes mountain seashore hexes from valid debark locations; 19.6.2 must-stop rule reinforces this"
     },
     {
       "id": "26.6_leader_fate_fleet_transport_destroyed",

--- a/docs/conformance/coverage_matrix.json
+++ b/docs/conformance/coverage_matrix.json
@@ -92,7 +92,8 @@
     ],
     "6.2.2": [
       "6.2.2_mountain_symbol_no_stop",
-      "6.2.2_no_mountain_symbol_must_stop"
+      "6.2.2_no_mountain_symbol_must_stop",
+      "6.2_mountain_symbol_leader_stack_movement"
     ],
     "6.3.1": [
       "6.3.1_home_kingdom_bonus_applies_monarch",
@@ -107,7 +108,8 @@
       "8.1_random_event_roll_two_dice"
     ],
     "8.2.1": [
-      "8.2.1_roll_two_untimely_death"
+      "8.2.1_roll_two_untimely_death",
+      "8.2_untimely_death_during_siege"
     ],
     "8.2.2": [
       "8.2.2_roll_three_storms"
@@ -243,18 +245,21 @@
     "12.3.2": [
       "12.3.2_deactivate_threshold",
       "12.3.2_deactivate_effects",
-      "12.3.2_deactivation_breaks_siege_coordination"
+      "12.3.2_deactivation_breaks_siege_coordination",
+      "28.2_player_death_deactivates_allies"
     ],
     "12.3.3": [
       "12.3.3_assassination_limit_once",
-      "12.3.3_assassination_higher_roll_kills"
+      "12.3.3_assassination_higher_roll_kills",
+      "12.3_assassination_kills_ambassador"
     ],
     "12.3.4": [
       "12.3.4_duel_limit_once",
       "12.3.4_duel_tie_kills_both"
     ],
     "12.4.1": [
-      "12.4.1_ambassador_death_removal"
+      "12.4.1_ambassador_death_removal",
+      "12.3_assassination_kills_ambassador"
     ],
     "12.4.3": [
       "12.4.3_no_diplomacy_during_death"
@@ -340,6 +345,22 @@
     "14.4": [
       "14.4_personality_effects_apply"
     ],
+    "15.1": [
+      "15.1_placement_hex_occupied_triggers_activation",
+      "15.1_non_combat_unit_no_trigger",
+      "28.1_confusion_border_violation_crowns_new_monarch"
+    ],
+    "15.2": [
+      "15.2_ambassador_placed_anywhere_in_kingdom"
+    ],
+    "15.3": [
+      "15.3_units_placed_normally_and_adjacent"
+    ],
+    "15.4": [
+      "15.4.1_siege_on_neutral_triggers_alliance",
+      "15.4_alliance_partner_random",
+      "15.4_siege_conditions_refigured"
+    ],
     "16.1": [
       "16.1_allied_forces_moved_by_owner"
     ],
@@ -415,7 +436,8 @@
     ],
     "17.6.1": [
       "17.6.1_siege_declared_when_conditions_met",
-      "12.3.2_deactivation_breaks_siege_coordination"
+      "12.3.2_deactivation_breaks_siege_coordination",
+      "8.2_untimely_death_during_siege"
     ],
     "17.6.2": [
       "17.6.2_any_player_may_declare"
@@ -428,13 +450,15 @@
     ],
     "17.7.2": [
       "17.7.2_must_attack_besiegers_first",
-      "17.7.2_leave_siege_after_resolution"
+      "17.7.2_leave_siege_after_resolution",
+      "17.7_leave_siege_full_movement"
     ],
     "17.7.3": [
       "17.7.3_attack_from_siege_combat_phase",
       "17.7.3_attack_from_siege_advance_limit",
       "17.7.3_outside_forces_join",
-      "17.7.3_attack_from_siege_breaks_siege"
+      "17.7.3_attack_from_siege_breaks_siege",
+      "25.13_advance_into_castle_siege_break"
     ],
     "17.8.1": [
       "17.8.1_resolution_in_siege_phase",
@@ -532,7 +556,8 @@
       "17.13.8_forced_peace_alternative_normal_diplomacy"
     ],
     "17.13.9": [
-      "17.13.9_forced_peace_effects"
+      "17.13.9_forced_peace_effects",
+      "17.13_forced_peace_plunder_permanent"
     ],
     "17.13.10": [
       "17.13.10_forced_peace_violation_effect"
@@ -541,7 +566,8 @@
       "17.13.11_forced_peace_unit_status"
     ],
     "17.13.12": [
-      "17.13.12_plundered_castles_remain"
+      "17.13.12_plundered_castles_remain",
+      "17.13_forced_peace_plunder_permanent"
     ],
     "17.13.13": [
       "17.13.13_player_monarchs_not_subject"
@@ -553,7 +579,8 @@
       "18.1.2_any_direction_movement"
     ],
     "18.1.3": [
-      "18.1.3_movement_points_not_saved"
+      "18.1.3_movement_points_not_saved",
+      "17.7_leave_siege_full_movement"
     ],
     "18.1.4": [
       "18.1.4_minimum_movement_one_hex"
@@ -571,7 +598,8 @@
       "18.3.1_besieged_units_cannot_move"
     ],
     "18.3.2": [
-      "18.3.2_just_activated_cannot_move"
+      "18.3.2_just_activated_cannot_move",
+      "18.3_activated_kingdom_no_move_or_attack"
     ],
     "18.3.3": [
       "18.3.3_just_deactivated_cannot_move"
@@ -586,7 +614,8 @@
       "18.4.3_units_may_continue_independently"
     ],
     "18.5.1": [
-      "18.5.1_cannot_enter_enemy_hex"
+      "18.5.1_cannot_enter_enemy_hex",
+      "30.1_troll_regeneration_blocked_by_enemy"
     ],
     "18.5.2": [
       "18.5.2_allied_stacking_end_turn"
@@ -633,7 +662,8 @@
       "19.5.2_hills_mountain_symbol"
     ],
     "19.6.1": [
-      "19.6.1_mountain_terrain_cost"
+      "19.6.1_mountain_terrain_cost",
+      "22.4_debark_mountain_seashore_denied"
     ],
     "19.6.2": [
       "19.6.2_mountain_must_stop"
@@ -773,11 +803,13 @@
     "22.4": [
       "22.4_debark_friendly_port",
       "22.4_debark_seashore_no_mountains",
-      "22.4_debark_seashore_mountains_denied"
+      "22.4_debark_seashore_mountains_denied",
+      "22.4_debark_mountain_seashore_denied"
     ],
     "22.5": [
       "22.5_transported_units_no_other_move",
-      "22.5_transported_units_eliminated_in_combat"
+      "22.5_transported_units_eliminated_in_combat",
+      "26.6_leader_fate_fleet_transport_destroyed"
     ],
     "22.6": [
       "22.6_fleet_continue_moving"
@@ -801,7 +833,8 @@
       "24.2.1_allied_pass_through"
     ],
     "24.2.2": [
-      "24.2.2_allied_end_turn_denied"
+      "24.2.2_allied_end_turn_denied",
+      "25.2_retreat_into_allied_hex_stacking"
     ],
     "24.3.1": [
       "24.3.1_mercenary_stack_with_friendly"
@@ -845,7 +878,8 @@
       "25.2.3_stack_test_order"
     ],
     "25.2.4": [
-      "25.2.4_retreat_destination"
+      "25.2.4_retreat_destination",
+      "25.2_retreat_into_allied_hex_stacking"
     ],
     "25.2.5": [
       "25.2.5_same_hex_retreat"
@@ -901,7 +935,8 @@
       "25.7.2_siege_attackers_cannot_combat",
       "25.7.2_transported_units_no_combat",
       "25.7.2_activated_kingdom_no_attack",
-      "25.7.2_deactivated_kingdom_no_attack"
+      "25.7.2_deactivated_kingdom_no_attack",
+      "18.3_activated_kingdom_no_move_or_attack"
     ],
     "25.8.1": [
       "25.8.1_cannot_attack_inside_castle"
@@ -910,10 +945,12 @@
       "25.8.2_adjacency_required_for_attack"
     ],
     "25.9.1": [
-      "25.9.1_multiple_hexes_combine"
+      "25.9.1_multiple_hexes_combine",
+      "25.9_multi_hex_allied_combined_attack"
     ],
     "25.9.2": [
-      "25.9.2_allied_forces_combine"
+      "25.9.2_allied_forces_combine",
+      "25.9_multi_hex_allied_combined_attack"
     ],
     "25.10.1": [
       "25.10.1_unit_attack_limit"
@@ -941,7 +978,8 @@
       "25.12.3_all_defenders_attacked"
     ],
     "25.13.1": [
-      "25.13.1_advance_trigger"
+      "25.13.1_advance_trigger",
+      "25.13_advance_into_castle_siege_break"
     ],
     "25.13.2": [
       "25.13.2_advance_units_choice"
@@ -963,7 +1001,9 @@
       "26.3.1_leader_movement_bonus_scope"
     ],
     "26.3.2": [
-      "26.3.2_stack_uses_leader_ma"
+      "26.3.2_stack_uses_leader_ma",
+      "26.3_leader_terrain_no_transfer_to_stack",
+      "6.2_mountain_symbol_leader_stack_movement"
     ],
     "26.3.3": [
       "26.3.3_begin_end_stacked"
@@ -975,7 +1015,8 @@
       "26.3.5_no_independent_movement_with_leader"
     ],
     "26.3.6": [
-      "26.3.6_unit_terrain_no_transfer"
+      "26.3.6_unit_terrain_no_transfer",
+      "26.3_leader_terrain_no_transfer_to_stack"
     ],
     "26.4.1": [
       "26.4.1_leader_combat_bonus_source"
@@ -998,7 +1039,8 @@
       "26.6.1_fate_roll_enemy_passes_lone_leader",
       "26.6.1_fate_roll_castle_falls",
       "26.6.1_fate_roll_leave_besieged_alone",
-      "26.6.1_fate_roll_fleet_lost_at_sea"
+      "26.6.1_fate_roll_fleet_lost_at_sea",
+      "26.6_leader_fate_fleet_transport_destroyed"
     ],
     "26.6.2": [
       "26.6.2_fate_roll_one_killed",
@@ -1049,7 +1091,8 @@
       "27.9_diplomacy_allowed_with_castaway"
     ],
     "28.1.1": [
-      "28.1.1_non_player_death_confusion"
+      "28.1.1_non_player_death_confusion",
+      "8.2_untimely_death_during_siege"
     ],
     "28.1.2": [
       "28.1.2_confusion_duration_roll"
@@ -1061,16 +1104,19 @@
       "28.1.4_confusion_end_new_personality"
     ],
     "28.1.5": [
-      "28.1.5_border_violation_ends_confusion"
+      "28.1.5_border_violation_ends_confusion",
+      "28.1_confusion_border_violation_crowns_new_monarch"
     ],
     "28.1.6": [
       "28.1.6_eliminated_regulars_remain"
     ],
     "28.2.1": [
-      "28.2.1_player_monarch_death_eliminates_player"
+      "28.2.1_player_monarch_death_eliminates_player",
+      "28.2_player_death_deactivates_allies"
     ],
     "28.2.2": [
-      "28.2.2_allies_deactivate"
+      "28.2.2_allies_deactivate",
+      "28.2_player_death_deactivates_allies"
     ],
     "28.2.3": [
       "28.2.3_player_kingdom_confusion"
@@ -1186,7 +1232,8 @@
     ],
     "30.1.4": [
       "30.1.4_troll_regeneration",
-      "30.1.4_troll_regeneration_blocked"
+      "30.1.4_troll_regeneration_blocked",
+      "30.1_troll_regeneration_blocked_by_enemy"
     ],
     "30.2.1": [
       "30.2.1_goblin_deploy_mountain_pass_only",

--- a/docs/conformance/coverage_matrix.json
+++ b/docs/conformance/coverage_matrix.json
@@ -105,7 +105,7 @@
       "6.3.2_home_kingdom_both_bonuses"
     ],
     "8.1": [
-      "8.1_random_event_roll_two_dice"
+      "8.1_random_events_dice_roll"
     ],
     "8.2.1": [
       "8.2.1_roll_two_untimely_death",
@@ -121,7 +121,8 @@
       "8.2.4_roll_five_bad_omens"
     ],
     "8.2.5": [
-      "8.2.5_roll_six_replacements"
+      "8.2.5_roll_six_replacements",
+      "8.2.5_replacement_player_or_allied_only"
     ],
     "8.2.6": [
       "8.2.6_roll_seven_no_event"
@@ -142,29 +143,32 @@
       "8.2.11_roll_twelve_help_from_afar"
     ],
     "8.3.1": [
-      "8.3.1_event_applies_only_to_roller"
+      "8.3.1_applies_only_to_rolling_player"
     ],
     "8.3.2": [
-      "8.3.2_regular_placement_at_counter"
+      "8.3.2_regular_placement_at_counter_location"
     ],
     "8.3.3": [
-      "8.3.3_blocked_placement_fails"
+      "8.3.3_blocked_placement_no_entry",
+      "8.3.3_besieged_hex_blocked"
     ],
     "8.3.4": [
-      "8.3.4_mercenary_placement_friendly"
+      "8.3.4_mercenary_placement_friendly_castle"
     ],
     "8.3.5": [
       "8.3.5_fleet_reinforcement_requires_port"
     ],
     "8.3.6": [
-      "8.3.6_regular_limit_respected"
+      "8.3.6_regular_limit_identity_card"
     ],
     "8.3.7": [
-      "8.3.7_immediate_action_for_replacements",
+      "8.3.7_immediate_action_allowed",
       "8.3.7_random_event_during_siege"
     ],
     "8.3.8": [
-      "8.3.8_impossible_event_no_event"
+      "8.3.8_impossible_event_no_event",
+      "8.3.8_no_fleets_storms_no_event",
+      "8.3.8_no_mercenaries_desertion_no_event"
     ],
     "8.3.9": [
       "8.3.9_no_transfer_between_players"
@@ -211,94 +215,100 @@
       "11.2.2_random_neutral_kingdoms"
     ],
     "12.1.1": [
-      "12.1.1_diplomacy_only_between",
+      "12.1.1_diplomacy_between_player_and_non_player",
+      "12.1.1_no_player_to_player_diplomacy",
       "12.1.1_diplomacy_with_captured_monarch"
     ],
     "12.1.2": [
       "12.1.2_player_alliances_not_binding"
     ],
     "12.1.3": [
-      "12.1.3_ambassador_death_recovery_turns"
+      "12.1.3_ambassador_death_recovery"
     ],
     "12.1.4": [
-      "12.1.4_ambassador_teleport_movement"
+      "12.1.4_ambassador_teleports"
     ],
     "12.1.5": [
       "12.1.5_ambassador_return_blocked"
     ],
     "12.2.1": [
-      "12.2.1_threshold_comparison"
+      "12.2.1_success_requires_threshold",
+      "12.2.1_below_threshold_fails"
     ],
     "12.2.2": [
-      "12.2.2_card_played_before_roll"
+      "12.2.2_card_before_roll"
     ],
     "12.2.3": [
-      "12.2.3_modified_result_formula"
+      "12.2.3_modified_result_calculation"
     ],
     "12.2.4": [
       "12.2.4_automatic_success"
     ],
     "12.3.1": [
-      "12.3.1_activate_neutral_threshold",
-      "12.3.1_activate_neutral_effects"
+      "12.3.1_activate_neutral_ambassador_placement",
+      "12.3.1_activate_threshold_six",
+      "12.3.1_activate_success_effect"
     ],
     "12.3.2": [
-      "12.3.2_deactivate_threshold",
-      "12.3.2_deactivate_effects",
+      "12.3.2_deactivate_ambassador_placement",
+      "12.3.2_deactivate_threshold_seven",
+      "12.3.2_deactivate_success_threshold",
+      "12.3.2_deactivate_forces_removed",
+      "12.3.2_mercenaries_stay_with_owner",
       "12.3.2_deactivation_breaks_siege_coordination",
       "28.2_player_death_deactivates_allies"
     ],
     "12.3.3": [
-      "12.3.3_assassination_limit_once",
-      "12.3.3_assassination_higher_roll_kills",
+      "12.3.3_assassination_once_per_game",
+      "12.3.3_assassination_no_diplomacy_cards",
+      "12.3.3_assassination_higher_roll_wins",
+      "12.3.3_assassination_tie_no_effect",
+      "12.3.3_assassination_no_victory_points",
+      "12.3.3_assassination_failure_banishment",
       "12.3_assassination_kills_ambassador"
     ],
     "12.3.4": [
-      "12.3.4_duel_limit_once",
-      "12.3.4_duel_tie_kills_both"
+      "12.3.4_duel_once_per_pair",
+      "12.3.4_duel_placement",
+      "12.3.4_duel_lower_roll_dies",
+      "12.3.4_duel_tie_both_die",
+      "12.3.4_duel_cannot_refuse"
     ],
     "12.4.1": [
-      "12.4.1_ambassador_death_removal",
+      "12.4.1_ambassador_death_effect",
       "12.3_assassination_kills_ambassador"
     ],
     "12.4.3": [
       "12.4.3_no_diplomacy_during_death"
     ],
-    "12.4.4": [
-      "12.4.4_ambassador_recovery_turn"
-    ],
     "12.4.5": [
       "12.4.5_penalties_inherited"
     ],
     "12.4.6": [
-      "12.4.6_continue_card_draw"
+      "12.4.6_card_draw_continues"
     ],
     "12.5.1": [
       "12.5.1_banishment_triggering_cards"
     ],
-    "12.5.2": [
-      "12.5.2_banishment_on_failed_roll"
-    ],
     "12.5.3": [
-      "12.5.3_banishment_duration_formula"
+      "12.5.3_banishment_duration"
     ],
     "12.5.4": [
       "12.5.4_banishment_effect"
     ],
     "12.5.5": [
-      "12.5.5_multiple_banishments_add"
-    ],
-    "12.5.6": [
-      "12.5.6_card_discard_before_result"
+      "12.5.5_multiple_banishments_cumulative"
     ],
     "12.6.1": [
-      "12.6.1_penalty_trigger_border_violation"
+      "12.6.1_diplomatic_penalty_trigger"
     ],
     "12.6.2": [
-      "12.6.2_penalty_effect_minus_one"
+      "12.6.2_penalty_minus_one"
     ],
     "12.6.3": [
-      "12.6.3_penalty_exceptions"
+      "12.6.3_no_penalty_allied_kingdom",
+      "12.6.3_no_penalty_enemy_allied",
+      "12.6.3_no_penalty_unclaimed"
     ],
     "12.6.4": [
       "12.6.4_penalty_not_cumulative"
@@ -306,44 +316,52 @@
     "12.6.5": [
       "12.6.5_deactivation_grace_period"
     ],
-    "12.6.6": [
-      "12.6.6_voluntary_elimination_avoids_penalty"
-    ],
     "13.1": [
-      "13.1_total_cards"
+      "13.1_total_diplomacy_cards"
     ],
     "13.2": [
       "13.2_basic_game_cards"
     ],
     "13.3.1": [
-      "13.3.1_diplomatic_ploys_bonus"
-    ],
-    "13.3.2": [
-      "13.3.2_special_mercenary_count"
+      "13.3.1_diplomatic_ploys_grant_bonus",
+      "13.3.1_bribes_plus_two",
+      "13.3.1_black_magic_plus_three",
+      "13.3.1_crass_bribes_banishment_risk",
+      "13.3.1_threats_banishment_risk",
+      "13.3.1_blackmail_banishment_risk",
+      "13.3.1_white_magic_safe",
+      "13.3.1_marriages_safe"
     ],
     "13.4": [
-      "13.4_cards_accumulate"
+      "13.4_cards_may_accumulate"
     ],
     "13.5": [
-      "13.5_cards_not_tradable"
+      "13.5_cards_no_trading"
     ],
     "13.6": [
       "13.6_reshuffle_when_exhausted"
     ],
     "13.7": [
-      "13.7_discard_after_use"
+      "13.7_card_discarded_regardless_of_outcome",
+      "13.7_card_discarded_on_failure"
     ],
     "14.1": [
       "14.1_total_personality_cards"
     ],
     "14.2": [
-      "14.2_assignment_one_per_monarch"
+      "14.2_one_per_non_player_monarch"
     ],
     "14.3": [
-      "14.3_reveal_on_ambassador_visit"
+      "14.3_reveal_when_ambassador_visits"
     ],
     "14.4": [
-      "14.4_personality_effects_apply"
+      "14.4_personality_diplomacy_bonus",
+      "14.4_personality_diplomacy_penalty",
+      "14.4_personality_movement_bonus",
+      "14.4_personality_combat_bonus",
+      "14.4_personality_multiple_effects",
+      "14.4_personality_applies_to_specific_ploys",
+      "14.4_personality_no_apply_wrong_ploy"
     ],
     "15.1": [
       "15.1_placement_hex_occupied_triggers_activation",
@@ -378,64 +396,61 @@
       "16.5_mercenary_stacking_with_friendly"
     ],
     "17.1.1": [
-      "17.1.1_castle_surrounded_required"
+      "17.1.1_castle_must_be_surrounded",
+      "17.1.1_castle_surrounded_valid"
     ],
     "17.1.2": [
       "17.1.2_no_outside_defenders"
     ],
     "17.1.3": [
-      "17.1.3_sufficient_force"
+      "17.1.3_sufficient_force_required",
+      "17.1.3_minimum_force_exactly_met"
     ],
     "17.2": [
-      "17.2_cooperation_rule_no_combined_strength"
+      "17.2_different_players_separate_sieges"
     ],
     "17.3.1": [
-      "17.3.1_zone_extends_adjacent"
+      "17.3.1_zone_of_siege_extends_one_hex"
     ],
     "17.3.2": [
-      "17.3.2_zone_all_sea_only"
+      "17.3.2_fleet_zone_sea_only"
     ],
     "17.3.3": [
-      "17.3.3_zone_all_land_only"
+      "17.3.3_land_unit_zone_land_only"
     ],
     "17.3.4": [
-      "17.3.4_zone_not_negated_by_friendly_units"
+      "17.3.4_friendly_units_no_negate_zone"
     ],
     "17.4.1": [
-      "17.4.1_units_inside_tracked"
+      "17.4.1_track_units_inside_inverted"
     ],
     "17.4.2": [
-      "17.4.2_outside_units_must_be_eliminated"
-    ],
-    "17.4.3": [
-      "17.4.3_outside_units_attacked_in_combat_phase"
+      "17.4.2_outside_units_must_be_cleared"
     ],
     "17.4.4": [
-      "17.4.4_retreat_into_castle_before_combat"
+      "17.4.4_retreat_into_castle"
     ],
     "17.4.5": [
-      "17.4.5_leader_bonus_not_outside"
+      "17.4.5_leader_inside_no_bonus_outside"
     ],
     "17.4.6": [
-      "17.4.6_move_in_out_no_cost"
-    ],
-    "17.4.7": [
-      "17.4.7_move_only_during_movement_phase"
+      "17.4.6_no_movement_cost_castle_entry"
     ],
     "17.5.1": [
-      "17.5.1_intrinsic_defense_from_hex"
+      "17.5.1_intrinsic_defense_on_counter"
     ],
     "17.5.2": [
-      "17.5.2_intrinsic_defense_only_for_siege"
+      "17.5.2_intrinsic_defense_only"
     ],
     "17.5.3": [
-      "17.5.3_intact_castle_blocks_entry"
+      "17.5.3_intact_castle_blocks_entry",
+      "17.5.3_ambassador_may_enter_castle"
     ],
     "17.5.4": [
       "17.5.4_plundered_castle_no_defense"
     ],
     "17.6.1": [
-      "17.6.1_siege_declared_when_conditions_met",
+      "17.6.1_siege_declared_instantly",
       "12.3.2_deactivation_breaks_siege_coordination",
       "8.2_untimely_death_during_siege"
     ],
@@ -443,134 +458,114 @@
       "17.6.2_any_player_may_declare"
     ],
     "17.6.3": [
-      "17.6.3_retreat_before_combat_not_besieging"
+      "17.6.3_retreated_units_not_besieging"
     ],
     "17.7.1": [
       "17.7.1_reinforcements_blocked"
     ],
     "17.7.2": [
-      "17.7.2_must_attack_besiegers_first",
-      "17.7.2_leave_siege_after_resolution",
+      "17.7.2_leaving_must_attack_first",
+      "17.7.2_exit_after_attack",
       "17.7_leave_siege_full_movement"
     ],
     "17.7.3": [
-      "17.7.3_attack_from_siege_combat_phase",
-      "17.7.3_attack_from_siege_advance_limit",
-      "17.7.3_outside_forces_join",
-      "17.7.3_attack_from_siege_breaks_siege",
+      "17.7.3_attack_from_siege_alternative",
+      "17.7.3_advance_limit_one_hex",
       "25.13_advance_into_castle_siege_break"
     ],
     "17.8.1": [
-      "17.8.1_resolution_in_siege_phase",
+      "17.8.1_resolution_timing",
       "8.3.7_random_event_during_siege"
     ],
     "17.8.2": [
-      "17.8.2_siege_roll_single_die"
+      "17.8.2_siege_roll_procedure"
     ],
     "17.8.3": [
-      "17.8.3_siege_roll_one_to_five_no_effect"
+      "17.8.3_roll_one_to_five_continues"
     ],
     "17.8.4": [
-      "17.8.4_siege_roll_six_taken"
+      "17.8.4_roll_six_castle_taken",
+      "17.8.4_modified_six_castle_taken"
     ],
     "17.8.5": [
-      "17.8.5_siege_attackers_no_move_after"
+      "17.8.5_siege_attackers_no_further_action"
     ],
     "17.9.1": [
       "17.9.1_siege_modifier_formula"
     ],
     "17.9.2": [
-      "17.9.2_siege_modifier_drop_fraction"
+      "17.9.2_siege_modifier_fractions_dropped"
     ],
     "17.9.3": [
-      "17.9.3_siege_modifier_applies_to_attacker"
-    ],
-    "17.9.4": [
-      "17.9.4_siege_modifier_example_one"
-    ],
-    "17.9.5": [
-      "17.9.5_siege_modifier_example_two"
-    ],
-    "17.9.6": [
-      "17.9.6_siege_modifier_example_three"
+      "17.9.3_siege_modifier_high"
     ],
     "17.10.1": [
       "17.10.1_plundered_castle_nonexistent"
     ],
     "17.10.2": [
-      "17.10.2_plundered_castle_placement_hex"
-    ],
-    "17.10.3": [
-      "17.10.3_plundered_royal_castle_diplomacy"
+      "17.10.2_plundered_retains_placement"
     ],
     "17.10.4": [
-      "17.10.4_plundered_castle_makes_friendly"
+      "17.10.4_occupation_makes_friendly"
     ],
     "17.10.5": [
-      "17.10.5_plundered_castle_permanent"
+      "17.10.5_plunder_permanent"
     ],
     "17.11.1": [
-      "17.11.1_fleets_participate_in_siege"
+      "17.11.1_fleets_contribute_siege"
     ],
     "17.11.2": [
-      "17.11.2_fleet_cannot_attack_all_land"
+      "17.11.2_fleets_no_all_land_attack"
     ],
     "17.11.3": [
       "17.11.3_port_siege_requires_fleet"
     ],
     "17.11.4": [
-      "17.11.4_port_siege_zone_coverage"
+      "17.11.4_port_sea_hexes_covered"
     ],
     "17.11.5": [
-      "17.11.5_seaborne_units_count_in_siege"
+      "17.11.5_seaborne_units_count_in_siege",
+      "17.11.5_seaborne_no_zone_of_siege"
     ],
     "17.12.1": [
-      "17.12.1_relief_force_procedure",
+      "17.12.1_relieving_force_procedure",
+      "17.12.1_relief_advance_on_loss",
       "17.12.1_relief_force_advances_two"
     ],
     "17.12.2": [
-      "17.12.2_relief_force_two_hex_advance"
+      "17.12.2_surrounded_castle_clear_hex"
     ],
     "17.12.3": [
-      "17.12.3_relief_force_post_options"
+      "17.12.3_forces_may_remain_outside"
     ],
     "17.13.1": [
       "17.13.1_forced_peace_trigger"
     ],
-    "17.13.2": [
-      "17.13.2_forced_peace_roll_timing"
-    ],
     "17.13.3": [
-      "17.13.3_forced_peace_special_roll"
+      "17.13.3_forced_peace_roll_type"
     ],
     "17.13.5": [
-      "17.13.5_forced_peace_success_rolls"
+      "17.13.5_forced_peace_success_five_six"
     ],
     "17.13.6": [
-      "17.13.6_forced_peace_contested_modifier"
+      "17.13.6_contested_only_six_succeeds"
     ],
     "17.13.7": [
-      "17.13.7_forced_peace_no_modifiers"
-    ],
-    "17.13.8": [
-      "17.13.8_forced_peace_alternative_normal_diplomacy"
+      "17.13.7_no_diplomacy_cards_forced_peace"
     ],
     "17.13.9": [
-      "17.13.9_forced_peace_effects",
+      "17.13.9_forced_peace_duration_roll",
+      "17.13.9_forced_peace_no_ambassadors",
       "17.13_forced_peace_plunder_permanent"
     ],
     "17.13.10": [
-      "17.13.10_forced_peace_violation_effect"
-    ],
-    "17.13.11": [
-      "17.13.11_forced_peace_unit_status"
+      "17.13.10_violation_ends_peace"
     ],
     "17.13.12": [
-      "17.13.12_plundered_castles_remain",
       "17.13_forced_peace_plunder_permanent"
     ],
     "17.13.13": [
-      "17.13.13_player_monarchs_not_subject"
+      "17.13.13_player_monarchs_no_forced_peace"
     ],
     "18.1.1": [
       "18.1.1_only_active_player_moves"
@@ -662,11 +657,11 @@
       "19.5.2_hills_mountain_symbol"
     ],
     "19.6.1": [
-      "19.6.1_mountain_terrain_cost",
-      "22.4_debark_mountain_seashore_denied"
+      "19.6.1_mountain_terrain_cost"
     ],
     "19.6.2": [
-      "19.6.2_mountain_must_stop"
+      "19.6.2_mountain_must_stop",
+      "22.4_debark_mountain_seashore_denied"
     ],
     "19.6.3": [
       "19.6.3_mountain_combat_bonus"
@@ -929,7 +924,8 @@
       "25.5.3_results_immediate"
     ],
     "25.6.1": [
-      "25.6.1_seaborne_units_eliminated"
+      "25.6.1_seaborne_units_eliminated",
+      "22.5_transported_units_eliminated_in_combat"
     ],
     "25.7.2": [
       "25.7.2_siege_attackers_cannot_combat",
@@ -1098,119 +1094,127 @@
       "28.1.2_confusion_duration_roll"
     ],
     "28.1.3": [
-      "28.1.3_confusion_restricts_regulars"
+      "28.1.3_regulars_defend_during_confusion",
+      "28.1.3_confusion_units_removed_at_turn_end",
+      "28.1.3_monarch_counter_on_time_track",
+      "28.1.3_no_diplomacy_during_confusion"
     ],
     "28.1.4": [
-      "28.1.4_confusion_end_new_personality"
+      "28.1.4_new_personality_at_confusion_end",
+      "28.1.4_old_personality_discarded"
     ],
     "28.1.5": [
-      "28.1.5_border_violation_ends_confusion",
+      "28.1.5_border_violation_during_confusion",
       "28.1_confusion_border_violation_crowns_new_monarch"
     ],
     "28.1.6": [
       "28.1.6_eliminated_regulars_remain"
     ],
     "28.2.1": [
-      "28.2.1_player_monarch_death_eliminates_player",
+      "28.2.1_player_monarch_death_elimination",
       "28.2_player_death_deactivates_allies"
     ],
     "28.2.2": [
-      "28.2.2_allies_deactivate",
+      "28.2.2_all_allies_deactivate",
       "28.2_player_death_deactivates_allies"
     ],
     "28.2.3": [
-      "28.2.3_player_kingdom_confusion"
+      "28.2.3_player_kingdom_enters_confusion"
     ],
     "28.2.4": [
-      "28.2.4_after_confusion_new_monarch"
+      "28.2.4_after_confusion_becomes_non_player"
     ],
     "28.2.5": [
       "28.2.5_player_keeps_victory_points"
     ],
     "28.2.6": [
-      "28.2.6_eliminated_player_can_win"
+      "28.2.6_posthumous_victory_possible"
     ],
     "28.2.7": [
-      "28.2.7_reentry_requires_approval"
+      "28.2.7_reentry_option",
+      "28.2.7_reentry_random_kingdom"
     ],
     "28.3.1": [
-      "28.3.1_prisoner_placed_nearest_castle"
+      "28.3.1_prisoner_placement_nearest_castle"
     ],
     "28.3.2": [
-      "28.3.2_no_castle_options"
+      "28.3.2_no_castle_execute_or_free"
     ],
     "28.3.3": [
       "28.3.3_capture_awards_points"
     ],
     "28.3.4": [
-      "28.3.4_prisoner_cannot_act",
+      "28.3.4_prisoner_no_transfer",
+      "28.3.4_prisoner_no_action",
+      "28.3.4_intrinsic_defense_serves_as_garrison",
       "12.1.1_diplomacy_with_captured_monarch"
     ],
     "28.3.5": [
-      "28.3.5_release_conditions"
+      "28.3.5_release_by_siege",
+      "28.3.5_release_by_deactivation"
     ],
     "28.3.6": [
       "28.3.6_release_placement"
     ],
     "28.4.1": [
-      "28.4.1_execute_prisoner_timing"
+      "28.4.1_execution_timing"
     ],
     "28.4.2": [
-      "28.4.2_execute_prisoner_no_points"
+      "28.4.2_execution_no_victory_points"
     ],
     "28.4.3": [
-      "28.4.3_execute_prisoner_penalty"
+      "28.4.3_execution_permanent_penalty"
     ],
     "28.5.1": [
-      "28.5.1_forced_peace_timing"
+      "28.5.1_forcing_peace_timing"
+    ],
+    "28.5.2": [
+      "28.5.2_in_addition_to_normal_diplomacy"
     ],
     "28.5.3": [
-      "28.5.3_forced_peace_success_rolls"
+      "28.5.3_forced_peace_success_roll"
     ],
     "28.5.4": [
-      "28.5.4_forced_peace_siege_modifier"
+      "28.5.4_besieged_prison_only_six"
     ],
     "28.5.5": [
-      "28.5.5_forced_peace_no_modifiers"
-    ],
-    "28.5.6": [
-      "28.5.6_forced_peace_alternative_diplomacy"
+      "28.5.5_no_modifiers_on_prisoner_peace"
     ],
     "28.5.7": [
-      "28.5.7_forced_peace_only_jailer"
-    ],
-    "28.5.8": [
-      "28.5.8_forced_peace_effects_reference"
+      "28.5.7_occupied_royal_castle_only_jailer"
     ],
     "29.1": [
-      "29.1_victory_points_determine_winner"
+      "29.1_victory_by_points"
     ],
     "29.2": [
-      "29.2_timed_victory_after_twenty_turns"
+      "29.2_highest_points_wins"
     ],
     "29.3.1": [
-      "29.3.1_plunder_castle_points"
+      "29.3.1_plunder_castle_points",
+      "29.3.1_plunder_castle_defense_three"
     ],
     "29.3.2": [
-      "29.3.2_plunder_royal_castle_points"
+      "29.3.2_plunder_royal_castle_points",
+      "29.3.2_plunder_royal_castle_defense_five"
     ],
     "29.3.3": [
-      "29.3.3_capture_enemy_allied_monarch"
+      "29.3.3_capture_allied_monarch_points"
     ],
     "29.3.4": [
-      "29.3.4_kill_enemy_allied_monarch"
+      "29.3.4_kill_allied_monarch_points"
     ],
     "29.3.5": [
-      "29.3.5_capture_or_kill_player_monarch"
+      "29.3.5_capture_player_monarch_points",
+      "29.3.5_kill_player_monarch_points"
     ],
     "29.4.1": [
-      "29.4.1_assassination_kill_no_points"
+      "29.4.1_assassination_no_points"
     ],
     "29.4.2": [
       "29.4.2_execute_prisoner_no_points"
     ],
     "29.4.3": [
-      "29.4.3_plunder_once_per_castle"
+      "29.4.3_castle_plunder_once_per_game"
     ],
     "29.4.4": [
       "29.4.4_plundered_status_permanent"
@@ -1222,47 +1226,59 @@
       "29.4.6_posthumous_victory"
     ],
     "30.1.1": [
-      "30.1.1_troll_setup_locations"
+      "30.1.1_troll_four_locations"
     ],
     "30.1.2": [
-      "30.1.2_troll_locations_no_castles"
+      "30.1.2_troll_locations_no_castles",
+      "30.1.2_troll_locations_free_entry"
     ],
     "30.1.3": [
-      "30.1.3_troll_monarch_start"
+      "30.1.3_troll_monarch_start_location"
     ],
     "30.1.4": [
-      "30.1.4_troll_regeneration",
+      "30.1.4_troll_regeneration_timing",
+      "30.1.4_troll_regeneration_one_unit",
+      "30.1.4_troll_regeneration_in_addition",
       "30.1.4_troll_regeneration_blocked",
+      "30.1.4_troll_same_turn_loss_no_regen",
+      "30.1.4_troll_no_eliminated_no_regen",
       "30.1_troll_regeneration_blocked_by_enemy"
     ],
     "30.2.1": [
-      "30.2.1_goblin_deploy_mountain_pass_only",
-      "30.2.1_goblin_one_per_hex",
-      "30.2.1_goblin_no_adjacency"
+      "30.2.1_goblin_nithmere_units",
+      "30.2.1_goblin_nithmere_location",
+      "30.2.1_goblin_nithmere_one_per_hex",
+      "30.2.1_goblin_nithmere_no_adjacency",
+      "30.2.1_goblin_nithmere_valid_placement",
+      "30.2.1_goblin_nithmere_applies_setup",
+      "30.2.1_goblin_nithmere_applies_replacement",
+      "30.2.1_goblin_nithmere_total_units"
     ],
     "30.3.1": [
-      "30.3.1_dwarf_setup_locations"
-    ],
-    "30.3.2": [
-      "30.3.2_dwarf_locations_listed"
+      "30.3.1_dwarves_three_locations"
     ],
     "30.3.3": [
-      "30.3.3_dwarf_unity_common_cause"
+      "30.3.3_dwarves_common_cause"
     ],
     "31.1": [
-      "31.1_cities_vs_castles_distinction"
+      "31.1_city_castle_distinction"
     ],
     "31.2.1": [
-      "31.2.1_city_without_castle_example"
+      "31.2.1_farnot_no_castle",
+      "31.2.1_yando_no_castle",
+      "31.2.1_lepers_no_castle",
+      "31.2.1_gorpin_no_castle",
+      "31.2.1_troll_locations_no_castle"
     ],
     "31.2.2": [
+      "31.2.2_city_without_castle_deployment",
       "31.2.2_city_without_castle_no_siege"
     ],
     "31.3.1": [
-      "31.3.1_castle_identified_in_hexmap"
+      "31.3.1_castle_identification"
     ],
     "31.3.2": [
-      "31.3.2_castle_provides_intrinsic_defense"
+      "31.3.2_castle_provides_defense"
     ]
   }
 }

--- a/docs/conformance/schema/test_case.schema.json
+++ b/docs/conformance/schema/test_case.schema.json
@@ -36,6 +36,21 @@
       "type": "object",
       "description": "Expected outcome from applying the rule"
     },
+    "action": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The boardgame.io move name to dispatch (e.g., 'RESOLVE_COMBAT', 'MOVE_UNIT')"
+        },
+        "args": {
+          "type": "object",
+          "description": "Arguments passed to the move function"
+        }
+      },
+      "required": ["type"],
+      "description": "Optional: boardgame.io move to dispatch, enabling transition-based testing"
+    },
     "tags": {
       "type": "array",
       "items": { "type": "string" },

--- a/docs/plans/2026-01-25-conformance-suite.md
+++ b/docs/plans/2026-01-25-conformance-suite.md
@@ -886,6 +886,48 @@ adjustments explicit and reproducible. Use semantic-style increments (e.g., `1.0
 Where a test depends on multiple rolls or chained random effects, include a deterministic roll
 sequence in `input.rolls` (e.g., `[6, 2, 5]`) and specify each consumption point in the description.
 
+### Recommended Input Vocabulary
+
+Use these field names consistently across test cases to reduce harness complexity. Not every test needs all fields — include only what's relevant.
+
+**Entities:**
+| Field | Type | Values | Used In |
+|-------|------|--------|---------|
+| `unit_type` | string | `"monarch"`, `"ambassador"`, `"regular_army"`, `"regular_fleet"`, `"mercenary_army"`, `"mercenary_fleet"` | Unit property tests |
+| `faction` | string | `"hothior"`, `"immer"`, `"mivior"`, `"muetar"`, `"pon"`, `"rombune"`, `"shucassam"`, `"neuth"`, `"ghem"`, `"zorn"`, `"trolls"` | Faction-specific tests |
+| `faction_type` | string | `"human"`, `"non_human"` | Retreat, classification |
+| `terrain` | string or array | `"clear"`, `"forest"`, `"mountain"`, `"hills"`, `"swamp"`, `"open_sea"`, `"seashore"`, `"lakeshore"`, `"mountain_pass"`, `"minor_river"`, `"major_river"`, `"scenic"` | Movement, terrain tests |
+| `hex` | `[col, row]` | Coordinates from hexmap | Positional tests |
+
+**Game State:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `active_player` | string | Player whose turn it is |
+| `game_phase` | string | `"movement"`, `"combat"`, `"siege"`, `"diplomacy"`, `"random_event"` |
+| `kingdom_status` | string | `"neutral"`, `"active"`, `"allied"`, `"confused"` |
+
+**Dice & Modifiers:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `roll` / `retreat_roll` / `fate_roll` / `siege_roll` | integer | 1-6 single die result |
+| `event_roll` | integer | 2-12 (2d6) |
+| `modifier` | integer | Applied modifier value |
+
+**Counts & Quantities:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `attacker_count` / `defender_count` | integer | Combat unit counts |
+| `besieging_units` / `units_inside` | integer | Siege force counts |
+| `intrinsic_defense` | integer | Castle defense value |
+| `stack_size` | integer | Units in stack |
+
+**Boolean Flags:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_combat_unit` / `is_leader` | boolean | Unit classification |
+| `must_stop` | boolean | Terrain stopping rule |
+| `move_allowed` / `attack_allowed` | boolean | Action permission |
+
 ---
 
 ## Task Breakdown

--- a/docs/plans/prototype_execution_strategy.md
+++ b/docs/plans/prototype_execution_strategy.md
@@ -1,7 +1,8 @@
 # Prototype Execution Strategy: Harness & Rendering
 
 **Date:** January 2026
-**Status:** Planned
+**Updated:** February 2026
+**Status:** Ready to Execute
 **Goal:** mitigate critical technical risks (Integration Complexity, Mobile Performance) identified in the Architecture Review.
 
 ---
@@ -26,13 +27,11 @@ Implement a "Vertical Slice" of the testing pipeline for a single, complex rule:
 
 #### 1.2 Schema-First Type Generation (Explicit State Mapping)
 *Recommendation Applied: Explicit State Mapping*
-- **Action:** Define the JSON Schema for the Combat Test Case first.
+- **Status:** Schema exists at `docs/conformance/schema/test_case.schema.json` (includes `action` field for transition-based testing).
 - **Tooling:** Configure `json-schema-to-typescript`.
-- **Pipeline:**
-  1.  Create `docs/conformance/schema/test_case.schema.json`.
-  2.  Run generator script.
-  3.  Output `src/types/conformance.d.ts`.
-  4.  **Constraint:** The Game Engine's `G` state must `implement` or `extend` this generated type to ensure alignment.
+- **Remaining:**
+  1.  Run generator script to output `src/types/conformance.d.ts`.
+  2.  **Constraint:** The Game Engine's `G` state must `implement` or `extend` this generated type to ensure alignment.
 
 #### 1.3 The Harness (Test Runner)
 *Recommendation Applied: Action-Based Testing*
@@ -128,5 +127,8 @@ Build a "Throwaway" prototype that renders the maximum theoretical load and meas
 | **Decision**| **Commit to Tech Stack** | Results of above | |
 
 ## 4. Immediate Next Steps
-1. Initialize the repository with `package.json` and dependencies (`boardgame.io`, `vitest`, `vite`).
-2. Create the `docs/conformance/schema/` directory.
+1. Initialize the repository with `package.json` and dependencies (`boardgame.io`, `vitest`, `vite`, `json-schema-to-typescript`).
+2. ~~Create the `docs/conformance/schema/` directory.~~ **Done** — schema exists with 463 validated tests across 7 chunks.
+3. Run type generator: `json-schema-to-typescript` against `test_case.schema.json` → `src/types/conformance.d.ts`.
+4. Implement `runConformanceTest()` harness utility targeting Rule 25.3 combat tests.
+5. Build rendering stress test (SVG candidate first).

--- a/scripts/validate_conformance_suite.py
+++ b/scripts/validate_conformance_suite.py
@@ -50,6 +50,10 @@ def validate_test_case(test_case, path: Path, index: int):
         raise ValidationError(
             f"{path} test[{index}] missing 'rule_ref' or 'rule_refs'"
         )
+    if rule_ref is not None and rule_refs is not None:
+        raise ValidationError(
+            f"{path} test[{index}] has both 'rule_ref' and 'rule_refs' (must be one or the other)"
+        )
 
     if rule_ref is not None:
         if not isinstance(rule_ref, str) or not RULE_PATTERN.match(rule_ref):
@@ -109,6 +113,7 @@ def validate_coverage_matrix(test_ids):
     if not isinstance(rules, dict):
         raise ValidationError("coverage_matrix.json 'rules' must be an object")
 
+    matrix_test_ids = set()
     for rule_ref, ids in rules.items():
         if not RULE_PATTERN.match(rule_ref):
             raise ValidationError(f"Invalid rule key in coverage matrix: {rule_ref}")
@@ -119,6 +124,13 @@ def validate_coverage_matrix(test_ids):
                 raise ValidationError(
                     f"Coverage matrix references missing test id '{test_id}'"
                 )
+            matrix_test_ids.add(test_id)
+
+    orphaned = test_ids - matrix_test_ids
+    if orphaned:
+        raise ValidationError(
+            f"Tests not tracked in coverage matrix: {sorted(orphaned)}"
+        )
 
 
 def main():


### PR DESCRIPTION
## Summary
- **Schema:** Added optional `action` field to `test_case.schema.json` for transition-based testing (boardgame.io move dispatch)
- **Integration tests:** Expanded from 5 to 20 cross-rule scenarios (leader terrain transfer, siege breakout, untimely death cascades, retreat stacking, forced peace permanence, etc.)
- **Rule 15 coverage:** Added 7 tests for Activating Violated Kingdom (previously zero coverage)
- **Validator fixes:** Added reverse coverage check (orphaned tests detected) and `oneOf` enforcement (`rule_ref`/`rule_refs` mutual exclusivity)
- **CI:** New GitHub Actions workflow runs `validate_conformance_suite.py` on PRs touching conformance files
- **Plans:** Updated prototype execution strategy to reflect current state; added recommended input vocabulary to conformance suite plan

Total validated tests: 441 → 463

## Test plan
- [x] `python3 scripts/validate_conformance_suite.py` passes with 463 tests
- [ ] CI workflow triggers on PR and passes
- [ ] Review new integration test scenarios for rule accuracy
- [ ] Review Rule 15 tests against dr3_rules.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)