### PR TITLE
Remove sub-agent launch restriction note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,4 +48,3 @@ TBD
 
 ## Skills
 You have skills in `.claude/skills/` - use them for debugging, TDD, planning, code review, etc.
-Never attempt to launch sub-agents, as you are running in web sandbox, and are unable to do so within your current sandbox. 


### PR DESCRIPTION
Removed note about launching sub-agents due to sandbox limitations.