### PR TITLE
feat: implement PRD runtime + UI + CI/E2E pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit + conformance adapters
+        run: npm test
+
+      - name: Validate conformance fixture suite
+        run: python3 scripts/validate_conformance_suite.py
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: End-to-end tests
+        run: npm run test:e2e
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,9 +1,8 @@
 name: Deploy Pages
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
+  push:
+    branches: ['main']
   workflow_dispatch:
 
 permissions:
@@ -17,16 +16,10 @@ concurrency:
 
 jobs:
   build:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,57 @@
+name: Deploy Pages
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static app
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}

--- a/docs/plans/2026-02-09-prd-execution-plan.md
+++ b/docs/plans/2026-02-09-prd-execution-plan.md
@@ -1,0 +1,85 @@
+# DR3 PRD Execution Plan (2026-02-09)
+
+This plan supersedes older working plans for implementation tracking against `docs/prd/divine-right-prd.md`.
+
+## Current status
+
+- `M1` Runtime architecture and deterministic domain rules: **Done**
+- `M2` boardgame.io wrapper and move flow: **Done**
+- `M3` Persistence + export/import: **Done**
+- `M4` CPU bot integration baseline: **Done**
+- `M5` React UI shell + SVG board + action sidebar: **Done**
+- `M6` Playwright E2E baseline (start, turn flow, save/load, CPU action): **Done**
+- `M7` CI/CD parity + GitHub Pages deploy pipeline: **Done**
+- `M8` Deep rules completion, richer UX and full interaction fidelity: **In progress**
+
+## Implemented deliverables
+
+### Engine and game runtime
+
+- Deterministic RNG utilities in `src/engine/domain/rng.ts`.
+- Runtime state initialization in `src/engine/domain/setup.ts`.
+- Domain action services in `src/engine/domain/rules.ts`:
+  - Random events
+  - Diplomacy
+  - Siege resolution
+  - Movement
+  - Combat declaration and resolution
+  - Turn scoring helpers
+- boardgame.io game config in `src/game/dr3-game.ts`.
+
+### Persistence and CPU
+
+- Local save/load, import/export in `src/persistence/save-load.ts`.
+- Boardgame bot integration in `src/ai/cpu-bot.ts`.
+
+### UI
+
+- App entrypoint in `index.html`, `src/main.tsx`, `src/App.tsx`.
+- SVG board rendering in `src/ui/HexBoard.tsx`.
+- Save/load/export/import controls and action controls.
+
+### Testing
+
+- New unit/integration tests for domain, game wrapper, persistence, CPU:
+  - `src/engine/domain/*.test.ts`
+  - `src/game/dr3-game.test.ts`
+  - `src/persistence/save-load.test.ts`
+  - `src/ai/cpu-bot.test.ts`
+- Playwright E2E suite:
+  - `src/test/e2e/app.spec.ts`
+- Playwright projects:
+  - `chromium`
+  - `ios-safari` (webkit + iPhone 13 device profile)
+
+### CI/CD and tooling
+
+- Unified CI pipeline: `.github/workflows/ci.yml`
+  - lint
+  - unit/conformance tests
+  - conformance fixture validation
+  - playwright e2e
+  - build
+- GitHub Pages deployment pipeline: `.github/workflows/deploy-pages.yml`
+- MCP Playwright setup:
+  - `.mcp.json`
+  - `docs/tooling/mcp-playwright.md`
+
+## Verification checklist
+
+Run locally:
+
+1. `npm run lint`
+2. `npm test`
+3. `python3 scripts/validate_conformance_suite.py`
+4. `npm run test:e2e:chromium`
+5. `npm run test:e2e:ios`
+6. `npm run build`
+
+## Next implementation targets
+
+1. Expand move legality and phase transitions to full PRD behavior.
+2. Promote more conformance chunks to direct runtime move-level assertions.
+3. Implement richer map interactions (zoom/pan, unit filtering, accessibility shortcuts).
+4. Improve CPU quality (objective heuristics, bounded response times).
+5. Add coverage thresholds for critical rule modules.

--- a/docs/tooling/mcp-playwright.md
+++ b/docs/tooling/mcp-playwright.md
@@ -1,0 +1,26 @@
+# MCP Playwright Setup
+
+This repository includes a local MCP configuration at `.mcp.json` that registers a Playwright MCP server.
+
+## Prerequisites
+
+- Node.js 24.x (same as CI)
+- Project dependencies installed with `npm ci`
+- Playwright browsers installed with `npx playwright install --with-deps`
+
+## Start MCP server
+
+Use the provided script:
+
+```bash
+npm run mcp:playwright
+```
+
+Or let your MCP-capable client load `.mcp.json` automatically.
+
+## Validation checks
+
+1. `npm run test:e2e:chromium`
+2. `npm run test:e2e:ios`
+
+If these pass locally, browser automation and CI browser environments are aligned.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DR3 - Divine Right</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "format": "prettier --write src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:chromium": "playwright test --project=chromium",
+    "test:e2e:ios": "playwright test --project=ios-safari",
+    "mcp:playwright": "npx -y @playwright/mcp@latest"
   },
   "dependencies": {
     "boardgame.io": "^0.50.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'ios-safari', use: { ...devices['iPhone 13'], browserName: 'webkit' } },
   ],
   webServer: {
     command: 'npm run dev',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
+import { Client } from 'boardgame.io/client';
+import { loadHexMap } from '@/data/load-refs';
+import { runCpuTurn } from '@/ai/cpu-bot';
+import { DR3Game } from '@/game/dr3-game';
+import {
+  createSaveSnapshot,
+  exportSave,
+  importSave,
+  loadGame,
+  saveGame,
+} from '@/persistence/save-load';
+import HexBoard from '@/ui/HexBoard';
+
+const dr3Client = Client({ game: DR3Game, numPlayers: 2, playerID: '0', debug: false });
+dr3Client.start();
+
+const staticHexMap = loadHexMap();
+const BOARD_HEXES = Array.from(staticHexMap.hexes.values()).map((hex) => ({
+  col: hex.col,
+  row: hex.row,
+  terrain: [...hex.terrain],
+}));
+
+type Dr3ClientState = ReturnType<typeof dr3Client.getState>;
+
+function downloadJson(filename: string, payload: string): void {
+  const blob = new Blob([payload], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function App() {
+  const [clientState, setClientState] = useState<Dr3ClientState>(dr3Client.getState());
+  const [selectedUnitId, setSelectedUnitId] = useState<string | null>(null);
+  const [statusText, setStatusText] = useState<string>('Ready.');
+
+  useEffect(() => {
+    return dr3Client.subscribe((state) => {
+      setClientState(state);
+    });
+  }, []);
+
+  const runtimeState = clientState?.G;
+  const currentPlayerId = clientState?.ctx.currentPlayer ?? '0';
+  const stage = runtimeState?.stage ?? 'rollEvents';
+
+  const selectedUnit = runtimeState && selectedUnitId ? runtimeState.units[selectedUnitId] : null;
+  const recentLog = useMemo(
+    () => (runtimeState?.log ?? []).slice(-16).reverse(),
+    [runtimeState?.log],
+  );
+
+  function getDiplomacyTarget(): string | null {
+    if (!runtimeState) return null;
+    return (
+      Object.keys(runtimeState.factions).find(
+        (id) => id !== runtimeState.players[currentPlayerId]?.homeFactionId,
+      ) ?? null
+    );
+  }
+
+  function handleHexSelect(col: number, row: number): void {
+    if (!runtimeState || stage !== 'movement' || !selectedUnitId) return;
+    dr3Client.moves.moveUnit?.(selectedUnitId, col, row);
+  }
+
+  function handleSave(): void {
+    if (!runtimeState) return;
+    saveGame('slot-a', runtimeState);
+    setStatusText('Saved to slot-a.');
+  }
+
+  function handleLoad(): void {
+    if (!clientState) return;
+    const loaded = loadGame('slot-a');
+    if (!loaded) {
+      setStatusText('No save found in slot-a.');
+      return;
+    }
+    const clientWithOverride = dr3Client as unknown as {
+      overrideGameState: (state: unknown) => void;
+    };
+    clientWithOverride.overrideGameState({
+      ...clientState,
+      G: loaded.state,
+    });
+    setStatusText('Loaded slot-a.');
+  }
+
+  function handleExport(): void {
+    if (!runtimeState) return;
+    const snapshot = createSaveSnapshot(runtimeState);
+    downloadJson(`dr3-save-${Date.now()}.json`, exportSave(snapshot));
+    setStatusText('Exported save file.');
+  }
+
+  async function handleImport(event: ChangeEvent<HTMLInputElement>): Promise<void> {
+    if (!clientState) return;
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const payload = await file.text();
+      const imported = importSave(payload);
+      const clientWithOverride = dr3Client as unknown as {
+        overrideGameState: (state: unknown) => void;
+      };
+      clientWithOverride.overrideGameState({
+        ...clientState,
+        G: imported.state,
+      });
+      setStatusText('Imported save file.');
+    } catch (error) {
+      setStatusText(
+        error instanceof Error ? `Import failed: ${error.message}` : 'Import failed.',
+      );
+    } finally {
+      event.target.value = '';
+    }
+  }
+
+  async function handleCpuTurn(): Promise<void> {
+    if (!runtimeState) return;
+    const steps = await runCpuTurn(dr3Client, currentPlayerId);
+    setStatusText(`CPU executed ${steps} actions.`);
+  }
+
+  if (!runtimeState || !clientState) {
+    return <div className="app-root">Loading game...</div>;
+  }
+
+  return (
+    <div className="app-root">
+      <header className="app-header">
+        <h1>Divine Right 3</h1>
+        <p>Single-player prototype aligned to conformance-first engine rules.</p>
+      </header>
+
+      <main className="layout">
+        <HexBoard
+          state={runtimeState}
+          hexes={BOARD_HEXES}
+          currentPlayerId={currentPlayerId}
+          selectedUnitId={selectedUnitId}
+          onSelectUnit={setSelectedUnitId}
+          onSelectHex={handleHexSelect}
+        />
+
+        <aside className="sidebar">
+          <section className="panel">
+            <h2>Turn</h2>
+            <div className="kv"><span>Turn</span><strong>{clientState.ctx.turn}</strong></div>
+            <div className="kv"><span>Player</span><strong>{currentPlayerId}</strong></div>
+            <div className="kv"><span>Stage</span><strong data-testid="stage-value">{stage}</strong></div>
+            <div className="status" data-testid="status-text">{statusText}</div>
+          </section>
+
+          <section className="panel">
+            <h2>Actions</h2>
+            <div className="actions">
+              <button data-testid="btn-roll-event" onClick={() => dr3Client.moves.rollRandomEvent?.()} disabled={stage !== 'rollEvents'}>
+                Roll Event
+              </button>
+              <button data-testid="btn-draw-card" onClick={() => dr3Client.moves.drawDiplomacyCard?.()} disabled={stage !== 'drawCard'}>
+                Draw Card
+              </button>
+              <button
+                data-testid="btn-diplomacy"
+                onClick={() => {
+                  const target = getDiplomacyTarget();
+                  if (target) dr3Client.moves.conductDiplomacy?.(target, 'activate');
+                }}
+                disabled={stage !== 'diplomacy'}
+              >
+                Conduct Diplomacy
+              </button>
+              <button data-testid="btn-resolve-sieges" onClick={() => dr3Client.moves.resolveSieges?.()} disabled={stage !== 'siegeResolution'}>
+                Resolve Sieges
+              </button>
+              <button data-testid="btn-to-combat" onClick={() => dr3Client.moves.toCombatPhase?.()} disabled={stage !== 'movement'}>
+                To Combat
+              </button>
+              <button data-testid="btn-end-turn" onClick={() => dr3Client.moves.endTurn?.()} disabled={stage !== 'combat'}>
+                End Turn
+              </button>
+              <button data-testid="btn-run-cpu" onClick={handleCpuTurn}>Run CPU</button>
+            </div>
+          </section>
+
+          <section className="panel">
+            <h2>Save/Load</h2>
+            <div className="actions">
+              <button data-testid="btn-save" onClick={handleSave}>Save Slot A</button>
+              <button data-testid="btn-load" onClick={handleLoad}>Load Slot A</button>
+              <button data-testid="btn-export" onClick={handleExport}>Export JSON</button>
+              <label className="file-label" data-testid="import-label">
+                Import JSON
+                <input data-testid="file-import" type="file" accept="application/json" onChange={handleImport} />
+              </label>
+            </div>
+          </section>
+
+          <section className="panel">
+            <h2>Selection</h2>
+            {selectedUnit ? (
+              <div className="selection">
+                <div className="kv"><span>Unit</span><strong>{selectedUnit.id}</strong></div>
+                <div className="kv"><span>Faction</span><strong>{selectedUnit.factionId}</strong></div>
+                <div className="kv"><span>Count</span><strong>{selectedUnit.count}</strong></div>
+                <div className="kv"><span>MP</span><strong>{selectedUnit.movementRemaining}</strong></div>
+              </div>
+            ) : (
+              <p className="muted">Select a unit stack from the board.</p>
+            )}
+          </section>
+
+          <section className="panel">
+            <h2>Turn Log</h2>
+            <ol className="turn-log">
+              {recentLog.map((entry, index) => (
+                <li key={`${index}-${entry}`}>{entry}</li>
+              ))}
+            </ol>
+          </section>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/src/ai/cpu-bot.test.ts
+++ b/src/ai/cpu-bot.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from 'boardgame.io/client';
+import { DR3Game } from '@/game/dr3-game';
+import { runCpuTurn } from './cpu-bot';
+
+function createClient() {
+  const client = Client({ game: DR3Game, numPlayers: 2, playerID: '0' });
+  client.start();
+  return client;
+}
+
+describe('cpu-bot', () => {
+  it('plays a full CPU turn with boardgame.io bot APIs', async () => {
+    const client = createClient();
+
+    const before = client.getState();
+    expect(before?.ctx.currentPlayer).toBe('0');
+    const beforeLogLength = before?.G.log.length ?? 0;
+
+    const steps = await runCpuTurn(client, '0');
+    expect(steps).toBeGreaterThan(0);
+
+    const after = client.getState();
+    expect(after).toBeTruthy();
+    expect((after?.G.log.length ?? 0) > beforeLogLength).toBe(true);
+  });
+});

--- a/src/ai/cpu-bot.ts
+++ b/src/ai/cpu-bot.ts
@@ -1,0 +1,137 @@
+import { MCTSBot } from 'boardgame.io/ai';
+import type { State } from 'boardgame.io';
+import { DR3Game, type RuntimeGameState } from '@/game/dr3-game';
+
+type CpuAction =
+  | {
+      type: 'MAKE_MOVE';
+      payload: { type: string; args?: unknown[]; playerID: string };
+    }
+  | {
+      type: 'GAME_EVENT';
+      payload: { type: string; args?: unknown[]; playerID: string };
+    };
+
+export interface CpuClientLike {
+  getState(): State<RuntimeGameState> | null;
+  moves: Record<string, (...args: unknown[]) => void>;
+}
+
+export function createCpuBot(
+  iterations: number = 60,
+  playoutDepth: number = 8,
+): MCTSBot {
+  return new MCTSBot({
+    game: DR3Game,
+    enumerate: DR3Game.ai?.enumerate,
+    iterations,
+    playoutDepth,
+    seed: 'dr3-cpu-seed',
+  });
+}
+
+function isMoveAction(action: CpuAction): action is Extract<CpuAction, { type: 'MAKE_MOVE' }> {
+  return action.type === 'MAKE_MOVE';
+}
+
+function runFallbackStep(
+  client: CpuClientLike,
+  state: State<RuntimeGameState>,
+): boolean {
+  const currentPlayer = state.ctx.currentPlayer;
+  switch (state.G.stage) {
+    case 'rollEvents':
+      client.moves.rollRandomEvent?.();
+      return true;
+    case 'drawCard':
+      client.moves.drawDiplomacyCard?.();
+      return true;
+    case 'diplomacy': {
+      const targetFactionId = Object.keys(state.G.factions).find(
+        (id) => id !== state.G.players[currentPlayer]?.homeFactionId,
+      );
+      if (!targetFactionId) return false;
+      client.moves.conductDiplomacy?.(targetFactionId, 'activate');
+      return true;
+    }
+    case 'siegeResolution':
+      client.moves.resolveSieges?.();
+      return true;
+    case 'movement':
+      client.moves.toCombatPhase?.();
+      return true;
+    case 'combat':
+      if (state.G.pendingCombats.length > 0) {
+        client.moves.resolveCombat?.();
+      } else {
+        client.moves.endTurn?.();
+      }
+      return true;
+    default:
+      return false;
+  }
+}
+
+export async function runCpuTurn(
+  client: CpuClientLike,
+  playerID: string,
+  maxSteps: number = 20,
+): Promise<number> {
+  const bot = createCpuBot();
+  let steps = 0;
+
+  while (steps < maxSteps) {
+    const state = client.getState();
+    if (!state) break;
+    if (state.ctx.currentPlayer !== playerID) break;
+    const stageBefore = state.G.stage;
+
+    const played = await bot.play(state, playerID);
+    const action = played.action as CpuAction;
+    const fallbackActions = DR3Game.ai?.enumerate(state.G, state.ctx, playerID) ?? [];
+
+    if (isMoveAction(action)) {
+      const moveDispatch = client.moves[action.payload.type];
+      if (moveDispatch) {
+        moveDispatch(...(action.payload.args ?? []));
+      }
+    }
+
+    const stateAfterBot = client.getState();
+    if (!stateAfterBot || stateAfterBot.ctx.currentPlayer !== playerID) {
+      steps += 1;
+      continue;
+    }
+
+    if (stateAfterBot.G.stage === stageBefore) {
+      const preferredFallback = fallbackActions.find(
+        (candidate) =>
+          'move' in candidate &&
+          ((stageBefore === 'movement' && candidate.move === 'toCombatPhase') ||
+            (stageBefore === 'combat' && candidate.move === 'endTurn')),
+      );
+      const fallback = preferredFallback ?? fallbackActions[0];
+      if (fallback && 'move' in fallback) {
+        const fallbackDispatch = client.moves[fallback.move];
+        if (fallbackDispatch) {
+          fallbackDispatch(...(fallback.args ?? []));
+        }
+      } else {
+        runFallbackStep(client, stateAfterBot);
+      }
+    }
+
+    steps += 1;
+  }
+
+  // Last-resort deterministic completion to keep CPU turns bounded in UI and tests.
+  while (steps < maxSteps * 2) {
+    const state = client.getState();
+    if (!state) break;
+    if (state.ctx.currentPlayer !== playerID) break;
+    if (!runFallbackStep(client, state)) break;
+    steps += 1;
+  }
+
+  return steps;
+}

--- a/src/engine/domain/rng.test.ts
+++ b/src/engine/domain/rng.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSeed, roll2d6, seedToState } from './rng';
+
+describe('rng', () => {
+  it('normalizes empty seed', () => {
+    expect(normalizeSeed('')).toBe('dr3-default-seed');
+  });
+
+  it('produces deterministic 2d6 sequence from seed', () => {
+    const stateA = seedToState('alpha');
+    const stateB = seedToState('alpha');
+
+    const firstA = roll2d6(stateA);
+    const firstB = roll2d6(stateB);
+    expect(firstA.total).toBe(firstB.total);
+
+    const secondA = roll2d6(firstA.nextState);
+    const secondB = roll2d6(firstB.nextState);
+    expect(secondA.total).toBe(secondB.total);
+  });
+});

--- a/src/engine/domain/rng.ts
+++ b/src/engine/domain/rng.ts
@@ -1,0 +1,73 @@
+const MODULUS = 0x100000000;
+const MULTIPLIER = 1664525;
+const INCREMENT = 1013904223;
+
+export interface RngRoll {
+  value: number;
+  nextState: number[];
+}
+
+export function hashSeed(seed: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function seedToState(seed: string): number[] {
+  return [hashSeed(seed)];
+}
+
+export function nextRng(state: number[]): RngRoll {
+  const current = state[0] ?? 0;
+  const value = (Math.imul(current, MULTIPLIER) + INCREMENT) >>> 0;
+  return { value, nextState: [value] };
+}
+
+export function nextInt(state: number[], maxExclusive: number): RngRoll {
+  if (maxExclusive <= 0) {
+    throw new Error('maxExclusive must be > 0');
+  }
+  const step = nextRng(state);
+  return { value: step.value % maxExclusive, nextState: step.nextState };
+}
+
+export function rollDie(state: number[], sides: number = 6): RngRoll {
+  const roll = nextInt(state, sides);
+  return { value: roll.value + 1, nextState: roll.nextState };
+}
+
+export function roll2d6(state: number[]): {
+  first: number;
+  second: number;
+  total: number;
+  nextState: number[];
+} {
+  const first = rollDie(state);
+  const second = rollDie(first.nextState);
+  return {
+    first: first.value,
+    second: second.value,
+    total: first.value + second.value,
+    nextState: second.nextState,
+  };
+}
+
+export function normalizeSeed(seed: string | undefined): string {
+  if (!seed || seed.trim() === '') return 'dr3-default-seed';
+  return seed;
+}
+
+export function normalizeRngState(
+  seed: string,
+  rngState: number[] | undefined,
+): number[] {
+  if (rngState && rngState.length > 0) return rngState;
+  return seedToState(seed);
+}
+
+export function toUnitInterval(value: number): number {
+  return value / MODULUS;
+}

--- a/src/engine/domain/rules.test.ts
+++ b/src/engine/domain/rules.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { buildInitialGameState } from './setup';
+import {
+  conductDiplomacyForPlayer,
+  drawDiplomacyCardForPlayer,
+  findFirstLegalMovement,
+  moveUnitForPlayer,
+  resolveSiegesForPlayer,
+  rollRandomEventForPlayer,
+  setStage,
+} from './rules';
+
+describe('domain rules', () => {
+  it('executes early turn stage actions', () => {
+    const state = buildInitialGameState({ seed: 'rules-seed' });
+    const playerID = state.turnOrder[0]!;
+
+    const randomEvent = rollRandomEventForPlayer(state, playerID);
+    expect(randomEvent.ok).toBe(true);
+
+    setStage(state, 'drawCard');
+    const draw = drawDiplomacyCardForPlayer(state, playerID);
+    expect(draw.ok).toBe(true);
+
+    setStage(state, 'diplomacy');
+    const targetFaction = Object.keys(state.factions).find(
+      (id) => id !== state.players[playerID]?.homeFactionId,
+    );
+    expect(targetFaction).toBeTruthy();
+    if (!targetFaction) return;
+
+    const diplomacy = conductDiplomacyForPlayer(state, playerID, targetFaction, 'activate');
+    expect(diplomacy.ok).toBe(true);
+
+    setStage(state, 'siegeResolution');
+    const sieges = resolveSiegesForPlayer(state, playerID);
+    expect(sieges.ok).toBe(true);
+  });
+
+  it('moves a unit when a legal move exists', () => {
+    const state = buildInitialGameState({ seed: 'move-seed' });
+    const playerID = state.turnOrder[0]!;
+    setStage(state, 'movement');
+
+    const move = findFirstLegalMovement(state, playerID);
+    if (!move) {
+      expect(move).toBeNull();
+      return;
+    }
+
+    const unitBefore = state.units[move.unitId];
+    expect(unitBefore).toBeTruthy();
+    if (!unitBefore) return;
+    const before = { ...unitBefore.position };
+    const result = moveUnitForPlayer(state, playerID, move.unitId, move.destination);
+    expect(result.ok).toBe(true);
+    const unitAfter = state.units[move.unitId];
+    expect(unitAfter).toBeTruthy();
+    if (!unitAfter) return;
+    expect(unitAfter.position).not.toEqual(before);
+  });
+});

--- a/src/engine/domain/rules.ts
+++ b/src/engine/domain/rules.ts
@@ -1,0 +1,481 @@
+import { calculateCombatModifier, resolveCombat } from '@/engine/combat/combat-resolution';
+import { getNeighborCoords } from '@/engine/map/hex-grid';
+import { calculateCumulativeTerrainCost } from '@/engine/map/terrain';
+import { canEnterHexByMp } from '@/engine/movement/movement';
+import { getCombatStrength, isCombatUnit } from '@/engine/units/unit-helpers';
+import { calculateSiegeModifier, resolveSiegeRoll } from '@/engine/siege/siege-resolution';
+import type { EventType, GameState, HexCoord, TurnStage, UnitState } from '@/types';
+import { hexKeyFromCoord } from '@/types';
+import { nextInt, roll2d6, rollDie } from './rng';
+
+export interface DomainResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface RandomEventResult extends DomainResult {
+  eventType?: EventType;
+  eventRoll?: number;
+}
+
+export interface CombatResolutionResult extends DomainResult {
+  attackerLosses?: number;
+  defenderLosses?: number;
+  winner?: 'attacker' | 'defender' | 'tie';
+}
+
+function fail(reason: string): DomainResult {
+  return { ok: false, reason };
+}
+
+function isCoordEqual(a: HexCoord, b: HexCoord): boolean {
+  return a.col === b.col && a.row === b.row;
+}
+
+function isAdjacent(G: GameState, from: HexCoord, to: HexCoord): boolean {
+  return getNeighborCoords(G.hexMap, from.col, from.row).some(
+    (coord) => coord.col === to.col && coord.row === to.row,
+  );
+}
+
+function getUnitsAtHex(G: GameState, coord: HexCoord): UnitState[] {
+  return Object.values(G.units).filter(
+    (unit) => unit.isAlive && isCoordEqual(unit.position, coord),
+  );
+}
+
+function getCombatUnitsAtHex(G: GameState, coord: HexCoord): UnitState[] {
+  return getUnitsAtHex(G, coord).filter((unit) => isCombatUnit(unit.unitType));
+}
+
+function canControlUnit(G: GameState, playerID: string, unit: UnitState): boolean {
+  const player = G.players[playerID];
+  if (!player) return false;
+  if (unit.factionId === player.homeFactionId) return true;
+
+  const faction = G.factions[unit.factionId];
+  if (faction?.controllingPlayerId === playerID) return true;
+
+  return unit.isMercenary;
+}
+
+function hasEnemyCombatUnitAtHex(
+  G: GameState,
+  coord: HexCoord,
+  factionId: string,
+): boolean {
+  return getCombatUnitsAtHex(G, coord).some((unit) => unit.factionId !== factionId);
+}
+
+function getTerrainAbilityFlags(unit: UnitState): {
+  hasTreeSymbol: boolean;
+  hasMountainSymbol: boolean;
+} {
+  return {
+    hasTreeSymbol: unit.abilities.includes('forest_walking'),
+    hasMountainSymbol: unit.abilities.includes('mountaineer'),
+  };
+}
+
+function removeLosses(units: UnitState[], losses: number): void {
+  let remainingLosses = losses;
+
+  for (const unit of units) {
+    if (remainingLosses <= 0) break;
+    const take = Math.min(unit.count, remainingLosses);
+    unit.count -= take;
+    remainingLosses -= take;
+    if (unit.count <= 0) {
+      unit.count = 0;
+      unit.isAlive = false;
+    }
+  }
+}
+
+function eventTypeFromRoll(total: number): EventType {
+  switch (total) {
+    case 2:
+      return 'untimely_death';
+    case 3:
+      return 'storms';
+    case 4:
+      return 'mutiny';
+    case 5:
+      return 'bad_omens';
+    case 6:
+      return 'replacements';
+    case 7:
+      return 'no_event';
+    case 8:
+      return 'reinforcements';
+    case 9:
+      return 'plague';
+    case 10:
+      return 'replacements';
+    case 11:
+      return 'desertion';
+    case 12:
+      return 'help_from_afar';
+    default:
+      return 'no_event';
+  }
+}
+
+export function setStage(G: GameState, stage: TurnStage): void {
+  G.stage = stage;
+}
+
+export function getStageForPlayer(G: GameState, playerID: string): TurnStage | null {
+  const activePlayer = G.turnOrder[G.activePlayerIndex];
+  if (activePlayer !== playerID) return null;
+  return G.stage;
+}
+
+export function rollRandomEventForPlayer(
+  G: GameState,
+  playerID: string,
+): RandomEventResult {
+  if (getStageForPlayer(G, playerID) !== 'rollEvents') {
+    return { ok: false, reason: 'wrong_stage' };
+  }
+
+  const roll = roll2d6(G.rngState);
+  G.rngState = roll.nextState;
+  const eventType = eventTypeFromRoll(roll.total);
+
+  G.log.push(
+    `P${playerID} rolled random event ${roll.first}+${roll.second}=${roll.total} (${eventType}).`,
+  );
+
+  return { ok: true, eventType, eventRoll: roll.total };
+}
+
+export function drawDiplomacyCardForPlayer(G: GameState, playerID: string): DomainResult {
+  if (getStageForPlayer(G, playerID) !== 'drawCard') {
+    return fail('wrong_stage');
+  }
+
+  const draw = nextInt(G.rngState, 45);
+  G.rngState = draw.nextState;
+  const cardId = `card-${draw.value + 1}`;
+  const hand = G.diplomacyDeck.playerHands[playerID];
+  if (!hand) return fail('unknown_player');
+
+  hand.push(cardId);
+  G.log.push(`P${playerID} drew ${cardId}.`);
+  return { ok: true };
+}
+
+export function conductDiplomacyForPlayer(
+  G: GameState,
+  playerID: string,
+  targetFactionId: string,
+  action: 'activate' | 'deactivate',
+): DomainResult {
+  if (getStageForPlayer(G, playerID) !== 'diplomacy') {
+    return fail('wrong_stage');
+  }
+
+  const target = G.factions[targetFactionId];
+  if (!target) return fail('unknown_faction');
+
+  if (action === 'activate') {
+    target.activationStatus = 'activated';
+    target.controllingPlayerId = playerID;
+  } else {
+    target.activationStatus = 'unactivated';
+    target.controllingPlayerId = null;
+  }
+
+  G.log.push(`P${playerID} diplomacy ${action} on ${targetFactionId}.`);
+  return { ok: true };
+}
+
+export function resolveSiegesForPlayer(G: GameState, playerID: string): DomainResult {
+  if (getStageForPlayer(G, playerID) !== 'siegeResolution') {
+    return fail('wrong_stage');
+  }
+
+  const player = G.players[playerID];
+  if (!player) return fail('unknown_player');
+
+  const playerFactionIds = new Set<string>([player.homeFactionId]);
+  for (const [factionId, state] of Object.entries(G.factions)) {
+    if (state.controllingPlayerId === playerID) {
+      playerFactionIds.add(factionId);
+    }
+  }
+
+  const sieges = G.sieges.filter((siege) => playerFactionIds.has(siege.besiegingFactionId));
+  if (sieges.length === 0) {
+    G.log.push(`P${playerID} has no sieges to resolve.`);
+    return { ok: true };
+  }
+
+  for (const siege of sieges) {
+    const roll = rollDie(G.rngState);
+    G.rngState = roll.nextState;
+    const intrinsicDefense = G.hexMap.hexes.get(hexKeyFromCoord(siege.hex))
+      ?.intrinsicDefense ?? 0;
+    const modifier = calculateSiegeModifier(
+      siege.besiegingUnitIds.length,
+      intrinsicDefense,
+      siege.defendingUnitIds.length,
+    );
+    const result = resolveSiegeRoll(roll.value, modifier);
+    siege.turnsUnderSiege += 1;
+    if (result.castleTaken) {
+      siege.isPlundered = true;
+    }
+    G.log.push(
+      `P${playerID} siege at ${siege.hex.col},${siege.hex.row} roll=${roll.value} mod=${modifier} taken=${result.castleTaken}.`,
+    );
+  }
+
+  return { ok: true };
+}
+
+export function moveUnitForPlayer(
+  G: GameState,
+  playerID: string,
+  unitId: string,
+  destination: HexCoord,
+): DomainResult {
+  if (getStageForPlayer(G, playerID) !== 'movement') {
+    return fail('wrong_stage');
+  }
+
+  const unit = G.units[unitId];
+  if (!unit || !unit.isAlive) return fail('unknown_or_dead_unit');
+  const legalMove = getLegalMovementCost(G, playerID, unit, destination);
+  if (!legalMove.ok) return fail(legalMove.reason ?? 'illegal_move');
+
+  unit.position = destination;
+  unit.movementRemaining = legalMove.minimumMovementApplies
+    ? 0
+    : Math.max(0, unit.movementRemaining - legalMove.terrainCost);
+  G.log.push(`P${playerID} moved ${unitId} to ${destination.col},${destination.row}.`);
+
+  return { ok: true };
+}
+
+function getLegalMovementCost(
+  G: GameState,
+  playerID: string,
+  unit: UnitState,
+  destination: HexCoord,
+): {
+  ok: boolean;
+  reason?: string;
+  terrainCost: number;
+  minimumMovementApplies: boolean;
+} {
+  if (!canControlUnit(G, playerID, unit)) {
+    return { ok: false, reason: 'not_controllable', terrainCost: 0, minimumMovementApplies: false };
+  }
+  if (!isAdjacent(G, unit.position, destination)) {
+    return { ok: false, reason: 'not_adjacent', terrainCost: 0, minimumMovementApplies: false };
+  }
+
+  const destinationHex = G.hexMap.hexes.get(hexKeyFromCoord(destination));
+  if (!destinationHex) {
+    return { ok: false, reason: 'invalid_destination', terrainCost: 0, minimumMovementApplies: false };
+  }
+  if (hasEnemyCombatUnitAtHex(G, destination, unit.factionId)) {
+    return { ok: false, reason: 'enemy_hex', terrainCost: 0, minimumMovementApplies: false };
+  }
+
+  const terrainCost = calculateCumulativeTerrainCost(
+    destinationHex.terrain,
+    getTerrainAbilityFlags(unit),
+  );
+  const movementCheck = canEnterHexByMp(
+    unit.movementRemaining,
+    terrainCost,
+    unit.movementRemaining === unit.movementPoints ? 0 : 1,
+  );
+  if (!movementCheck.entryAllowed) {
+    return { ok: false, reason: 'insufficient_movement', terrainCost, minimumMovementApplies: false };
+  }
+
+  return {
+    ok: true,
+    terrainCost,
+    minimumMovementApplies: movementCheck.minimumMovementApplies,
+  };
+}
+
+export function findFirstLegalMovement(
+  G: GameState,
+  playerID: string,
+): { unitId: string; destination: HexCoord } | null {
+  const units = Object.values(G.units).filter(
+    (unit) =>
+      unit.isAlive &&
+      unit.movementRemaining > 0 &&
+      canControlUnit(G, playerID, unit),
+  );
+
+  for (const unit of units) {
+    const neighbors = getNeighborCoords(G.hexMap, unit.position.col, unit.position.row);
+    for (const neighbor of neighbors) {
+      const check = getLegalMovementCost(G, playerID, unit, neighbor);
+      if (check.ok) {
+        return { unitId: unit.id, destination: neighbor };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function findFirstCombatPair(
+  G: GameState,
+  playerID: string,
+): { attacker: HexCoord; defender: HexCoord } | null {
+  const controlled = Object.values(G.units).filter(
+    (unit) => unit.isAlive && canControlUnit(G, playerID, unit) && isCombatUnit(unit.unitType),
+  );
+
+  for (const attacker of controlled) {
+    const neighbors = getNeighborCoords(
+      G.hexMap,
+      attacker.position.col,
+      attacker.position.row,
+    );
+    for (const neighbor of neighbors) {
+      const defenders = getCombatUnitsAtHex(G, neighbor).filter(
+        (unit) => unit.factionId !== attacker.factionId,
+      );
+      if (defenders.length > 0) {
+        return { attacker: attacker.position, defender: neighbor };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function declareCombatForPlayer(
+  G: GameState,
+  playerID: string,
+  attackerHex: HexCoord,
+  defenderHex: HexCoord,
+): DomainResult {
+  if (getStageForPlayer(G, playerID) !== 'combat') {
+    return fail('wrong_stage');
+  }
+  if (!isAdjacent(G, attackerHex, defenderHex)) return fail('not_adjacent');
+
+  const attackerUnits = getCombatUnitsAtHex(G, attackerHex).filter((unit) =>
+    canControlUnit(G, playerID, unit),
+  );
+  if (attackerUnits.length === 0) return fail('no_attacker_units');
+
+  const defenderUnits = getCombatUnitsAtHex(G, defenderHex).filter(
+    (unit) => unit.factionId !== attackerUnits[0]?.factionId,
+  );
+  if (defenderUnits.length === 0) return fail('no_defender_units');
+
+  G.pendingCombats.push({ attackerHex, defenderHex });
+  G.log.push(
+    `P${playerID} declared combat ${attackerHex.col},${attackerHex.row} -> ${defenderHex.col},${defenderHex.row}.`,
+  );
+  return { ok: true };
+}
+
+export function resolveNextCombatForPlayer(
+  G: GameState,
+  playerID: string,
+): CombatResolutionResult {
+  if (getStageForPlayer(G, playerID) !== 'combat') {
+    return { ok: false, reason: 'wrong_stage' };
+  }
+  const pending = G.pendingCombats.shift();
+  if (!pending) return { ok: false, reason: 'no_pending_combat' };
+
+  const attackerUnits = getCombatUnitsAtHex(G, pending.attackerHex).filter((unit) =>
+    canControlUnit(G, playerID, unit),
+  );
+  const defenderUnits = getCombatUnitsAtHex(G, pending.defenderHex).filter(
+    (unit) => unit.factionId !== attackerUnits[0]?.factionId,
+  );
+  if (attackerUnits.length === 0 || defenderUnits.length === 0) {
+    return { ok: false, reason: 'combatants_missing' };
+  }
+
+  const attackerStrength = attackerUnits.reduce(
+    (sum, unit) => sum + getCombatStrength(unit.unitType) * unit.count,
+    0,
+  );
+  const defenderStrength = defenderUnits.reduce(
+    (sum, unit) => sum + getCombatStrength(unit.unitType) * unit.count,
+    0,
+  );
+  if (attackerStrength <= 0 || defenderStrength <= 0) {
+    return { ok: false, reason: 'no_combat_strength' };
+  }
+
+  const modifier = calculateCombatModifier(attackerStrength, defenderStrength);
+  const attackRoll = rollDie(G.rngState);
+  const defendRoll = rollDie(attackRoll.nextState);
+  G.rngState = defendRoll.nextState;
+
+  const attackerModifier = modifier.appliesTo === 'attacker' ? modifier.modifier : 0;
+  const defenderModifier = modifier.appliesTo === 'defender' ? modifier.modifier : 0;
+  const outcome = resolveCombat(
+    attackRoll.value,
+    attackerModifier,
+    defendRoll.value,
+    defenderModifier,
+  );
+
+  removeLosses(attackerUnits, outcome.attackerLosses);
+  removeLosses(defenderUnits, outcome.defenderLosses);
+
+  G.log.push(
+    `Combat resolved at ${pending.attackerHex.col},${pending.attackerHex.row}: winner=${outcome.winner}, A-${outcome.attackerLosses}, D-${outcome.defenderLosses}.`,
+  );
+
+  return {
+    ok: true,
+    attackerLosses: outcome.attackerLosses,
+    defenderLosses: outcome.defenderLosses,
+    winner: outcome.winner,
+  };
+}
+
+export function startTurnForPlayer(G: GameState, playerID: string, turn: number): void {
+  G.currentTurn = turn;
+  G.phase = 'playerTurn';
+  G.stage = 'rollEvents';
+  G.activePlayerIndex = G.turnOrder.indexOf(playerID);
+  if (G.activePlayerIndex < 0) G.activePlayerIndex = 0;
+
+  for (const unit of Object.values(G.units)) {
+    if (unit.isAlive && canControlUnit(G, playerID, unit)) {
+      unit.movementRemaining = unit.movementPoints;
+    }
+  }
+}
+
+export function hasAnyPendingCombats(G: GameState): boolean {
+  return G.pendingCombats.length > 0;
+}
+
+export function scoreVictoryPointsFromFactionState(G: GameState): Record<string, number> {
+  const scores: Record<string, number> = {};
+  for (const playerID of G.turnOrder) {
+    scores[playerID] = 0;
+  }
+
+  for (const factionState of Object.values(G.factions)) {
+    if (factionState.controllingPlayerId) {
+      scores[factionState.controllingPlayerId] =
+        (scores[factionState.controllingPlayerId] ?? 0) +
+        factionState.victoryPoints;
+    }
+  }
+
+  return scores;
+}

--- a/src/engine/domain/setup.test.ts
+++ b/src/engine/domain/setup.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildInitialGameState } from './setup';
+
+describe('buildInitialGameState', () => {
+  it('creates a playable initial state', () => {
+    const state = buildInitialGameState({ seed: 'test-seed' });
+    expect(state.phase).toBe('playerTurn');
+    expect(state.stage).toBe('rollEvents');
+    expect(state.turnOrder).toHaveLength(2);
+    expect(Object.keys(state.units).length).toBeGreaterThan(0);
+    expect(state.seed).toBe('test-seed');
+    expect(state.rngState.length).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/domain/setup.ts
+++ b/src/engine/domain/setup.ts
@@ -1,0 +1,160 @@
+import {
+  loadFactions,
+  loadHexMap,
+  loadPersonalityCards,
+  loadUnitDefinitions,
+} from '@/data/load-refs';
+import type {
+  FactionData,
+  FactionState,
+  GameState,
+  PlayerState,
+  UnitDefinition,
+  UnitState,
+} from '@/types';
+import { normalizeSeed, seedToState } from './rng';
+
+interface SetupPlayer {
+  id: string;
+  homeFactionId: string;
+  isHuman: boolean;
+}
+
+export interface SetupOptions {
+  seed?: string;
+  players?: SetupPlayer[];
+  maxTurns?: number;
+}
+
+function buildPlayerStates(playerSlots: SetupPlayer[]): Record<string, PlayerState> {
+  const players: Record<string, PlayerState> = {};
+  for (const slot of playerSlots) {
+    players[slot.id] = {
+      id: slot.id,
+      homeFactionId: slot.homeFactionId,
+      isHuman: slot.isHuman,
+      hand: [],
+    };
+  }
+  return players;
+}
+
+function buildFactionDataRecord(factions: FactionData[]): Record<string, FactionData> {
+  const record: Record<string, FactionData> = {};
+  for (const faction of factions) {
+    record[faction.id] = faction;
+  }
+  return record;
+}
+
+function buildFactionStateRecord(factions: FactionData[]): Record<string, FactionState> {
+  const states: Record<string, FactionState> = {};
+  for (const faction of factions) {
+    states[faction.id] = {
+      id: faction.id,
+      activationStatus: 'unactivated',
+      controllingPlayerId: null,
+      personalityCardId: null,
+      monarchAlive: true,
+      ambassadorAlive: true,
+      ambassadorBanishedUntilTurn: null,
+      diplomacyPenalty: 0,
+      castlesOwned: faction.cities.map((city) => city.id),
+      victoryPoints: 0,
+    };
+  }
+  return states;
+}
+
+function buildUnitDefinitionRecord(units: UnitDefinition[]): Record<string, UnitDefinition> {
+  const record: Record<string, UnitDefinition> = {};
+  for (const definition of units) {
+    record[definition.id] = definition;
+  }
+  return record;
+}
+
+function toUnitState(definition: UnitDefinition): UnitState | null {
+  if (!definition.startHex) return null;
+
+  return {
+    id: definition.id,
+    definitionId: definition.id,
+    factionId: definition.factionId,
+    unitType: definition.unitType,
+    position: definition.startHex,
+    movementPoints: definition.movementPoints,
+    movementRemaining: definition.movementPoints,
+    abilities: definition.abilities,
+    movementType: definition.movementType,
+    count: definition.count,
+    isMercenary: definition.unitType.startsWith('mercenary'),
+    isAlive: true,
+    cityId: definition.cityId,
+  };
+}
+
+function buildUnitStateRecord(units: UnitDefinition[]): Record<string, UnitState> {
+  const record: Record<string, UnitState> = {};
+  for (const definition of units) {
+    const unit = toUnitState(definition);
+    if (unit) {
+      record[unit.id] = unit;
+    }
+  }
+  return record;
+}
+
+function defaultPlayers(factions: FactionData[]): SetupPlayer[] {
+  const factionIds = factions.slice(0, 2).map((f) => f.id);
+  return [
+    { id: '0', homeFactionId: factionIds[0] ?? 'hothior', isHuman: true },
+    { id: '1', homeFactionId: factionIds[1] ?? 'immer', isHuman: false },
+  ];
+}
+
+export function buildInitialGameState(options: SetupOptions = {}): GameState {
+  const seed = normalizeSeed(options.seed);
+  const hexMap = loadHexMap();
+  const factions = loadFactions();
+  const unitDefinitions = loadUnitDefinitions();
+  const personalityCards = loadPersonalityCards();
+  const playerSlots = options.players ?? defaultPlayers(factions);
+
+  const gameState: GameState = {
+    hexMap,
+    units: buildUnitStateRecord(unitDefinitions),
+    unitDefinitions: buildUnitDefinitionRecord(unitDefinitions),
+    factions: buildFactionStateRecord(factions),
+    factionData: buildFactionDataRecord(factions),
+    players: buildPlayerStates(playerSlots),
+    diplomacyDeck: {
+      drawPile: personalityCards.map((card) => `diplomacy-${card.id}`),
+      discardPile: [],
+      playerHands: Object.fromEntries(
+        playerSlots.map((slot) => [slot.id, [] as string[]]),
+      ),
+    },
+    sieges: [],
+    currentTurn: 1,
+    maxTurns: options.maxTurns ?? 20,
+    turnOrder: playerSlots.map((slot) => slot.id),
+    activePlayerIndex: 0,
+    phase: 'playerTurn',
+    stage: 'rollEvents',
+    pendingCombats: [],
+    log: [`Game initialized with seed "${seed}"`],
+    seed,
+    rngState: seedToState(seed),
+  };
+
+  for (const slot of playerSlots) {
+    const faction = gameState.factions[slot.homeFactionId];
+    if (faction) {
+      faction.controllingPlayerId = slot.id;
+      faction.activationStatus = 'activated';
+    }
+  }
+
+  return gameState;
+}

--- a/src/game/dr3-game.test.ts
+++ b/src/game/dr3-game.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from 'boardgame.io/client';
+import { DR3Game, toDomainState } from './dr3-game';
+import { findFirstCombatPair, findFirstLegalMovement } from '@/engine/domain/rules';
+
+function createClient() {
+  const client = Client({ game: DR3Game, numPlayers: 2 });
+  client.start();
+  return client;
+}
+
+function getCurrentPlayerStage(client: ReturnType<typeof createClient>): string | null {
+  const state = client.getState();
+  if (!state) return null;
+  return state.G.stage ?? null;
+}
+
+function runToMovement(client: ReturnType<typeof createClient>): void {
+  const state = client.getState();
+  if (!state) return;
+  const targetFactionId = Object.keys(state.G.factions).find(
+    (id) => id !== state.G.players[state.ctx.currentPlayer]?.homeFactionId,
+  );
+  if (!targetFactionId) return;
+  client.moves.rollRandomEvent?.();
+  client.moves.drawDiplomacyCard?.();
+  client.moves.conductDiplomacy?.(targetFactionId, 'activate');
+  client.moves.resolveSieges?.();
+}
+
+describe('DR3Game', () => {
+  it('starts in rollEvents stage', () => {
+    const client = createClient();
+    expect(getCurrentPlayerStage(client)).toBe('rollEvents');
+  });
+
+  it('advances through early phases via move flow', () => {
+    const client = createClient();
+    client.moves.rollRandomEvent?.();
+    expect(getCurrentPlayerStage(client)).toBe('drawCard');
+
+    client.moves.drawDiplomacyCard?.();
+    expect(getCurrentPlayerStage(client)).toBe('diplomacy');
+  });
+
+  it('moves a unit in movement stage when a legal move exists', () => {
+    const client = createClient();
+    runToMovement(client);
+    expect(getCurrentPlayerStage(client)).toBe('movement');
+
+    const state = client.getState();
+    expect(state).toBeTruthy();
+    if (!state) return;
+
+    const legalMove = findFirstLegalMovement(
+      toDomainState(state.G),
+      state.ctx.currentPlayer,
+    );
+    if (!legalMove) {
+      client.moves.toCombatPhase?.();
+      expect(getCurrentPlayerStage(client)).toBe('combat');
+      return;
+    }
+
+    const unitBefore = state.G.units[legalMove.unitId];
+    expect(unitBefore).toBeTruthy();
+    if (!unitBefore) return;
+    const previousPosition = { ...unitBefore.position };
+
+    client.moves.moveUnit?.(
+      legalMove.unitId,
+      legalMove.destination.col,
+      legalMove.destination.row,
+    );
+    const nextState = client.getState();
+    expect(nextState).toBeTruthy();
+    if (!nextState) return;
+
+    const unitAfter = nextState.G.units[legalMove.unitId];
+    expect(unitAfter).toBeTruthy();
+    if (!unitAfter) return;
+    expect(unitAfter.position).toEqual(legalMove.destination);
+    expect(unitAfter.position).not.toEqual(previousPosition);
+  });
+
+  it('handles combat declaration and resolution in combat stage', () => {
+    const client = createClient();
+    runToMovement(client);
+    client.moves.toCombatPhase?.();
+    expect(getCurrentPlayerStage(client)).toBe('combat');
+
+    const state = client.getState();
+    expect(state).toBeTruthy();
+    if (!state) return;
+
+    const pair = findFirstCombatPair(toDomainState(state.G), state.ctx.currentPlayer);
+    if (!pair) {
+      client.moves.endTurn?.();
+      expect(client.getState()).toBeTruthy();
+      return;
+    }
+
+    client.moves.declareCombat?.(
+      pair.attacker.col,
+      pair.attacker.row,
+      pair.defender.col,
+      pair.defender.row,
+    );
+    const withPending = client.getState();
+    expect(withPending).toBeTruthy();
+    expect(withPending?.G.pendingCombats.length).toBeGreaterThan(0);
+
+    client.moves.resolveCombat?.();
+    const resolved = client.getState();
+    expect(resolved).toBeTruthy();
+    expect(resolved?.G.log.length).toBeGreaterThan(0);
+  });
+});

--- a/src/game/dr3-game.ts
+++ b/src/game/dr3-game.ts
@@ -1,0 +1,180 @@
+import type { Game } from 'boardgame.io';
+import { INVALID_MOVE, TurnOrder } from 'boardgame.io/core';
+import type { GameState, TurnStage } from '@/types';
+import { loadHexMap } from '@/data/load-refs';
+import { buildInitialGameState, type SetupOptions } from '@/engine/domain/setup';
+import {
+  conductDiplomacyForPlayer,
+  declareCombatForPlayer,
+  drawDiplomacyCardForPlayer,
+  findFirstCombatPair,
+  findFirstLegalMovement,
+  hasAnyPendingCombats,
+  moveUnitForPlayer,
+  resolveNextCombatForPlayer,
+  resolveSiegesForPlayer,
+  rollRandomEventForPlayer,
+  scoreVictoryPointsFromFactionState,
+} from '@/engine/domain/rules';
+
+export type DR3SetupData = SetupOptions;
+export type RuntimeGameState = Omit<GameState, 'hexMap'>;
+
+const STATIC_HEX_MAP = loadHexMap();
+
+export function toDomainState(G: RuntimeGameState): GameState {
+  return { ...G, hexMap: STATIC_HEX_MAP };
+}
+
+function transitionStage(G: RuntimeGameState, nextStage: TurnStage): void {
+  G.stage = nextStage;
+}
+
+function ensureStage(G: RuntimeGameState, stage: TurnStage): boolean {
+  return G.stage === stage;
+}
+
+export const DR3Game: Game<RuntimeGameState, Record<string, unknown>, DR3SetupData> = {
+  name: 'dr3',
+  setup: (_context, setupData) => {
+    const initial = buildInitialGameState(setupData);
+    const runtime = Object.fromEntries(
+      Object.entries(initial).filter(([key]) => key !== 'hexMap'),
+    ) as RuntimeGameState;
+    return runtime;
+  },
+  disableUndo: false,
+  moves: {
+    rollRandomEvent: ({ G, playerID }) => {
+      if (!ensureStage(G, 'rollEvents')) return INVALID_MOVE;
+      const result = rollRandomEventForPlayer(toDomainState(G), playerID);
+      if (!result.ok) return INVALID_MOVE;
+      transitionStage(G, 'drawCard');
+    },
+    drawDiplomacyCard: ({ G, playerID }) => {
+      if (!ensureStage(G, 'drawCard')) return INVALID_MOVE;
+      const result = drawDiplomacyCardForPlayer(toDomainState(G), playerID);
+      if (!result.ok) return INVALID_MOVE;
+      transitionStage(G, 'diplomacy');
+    },
+    conductDiplomacy: ({ G, playerID }, factionId: string, action: 'activate' | 'deactivate' = 'activate') => {
+      if (!ensureStage(G, 'diplomacy')) return INVALID_MOVE;
+      const result = conductDiplomacyForPlayer(
+        toDomainState(G),
+        playerID,
+        factionId,
+        action,
+      );
+      if (!result.ok) return INVALID_MOVE;
+      transitionStage(G, 'siegeResolution');
+    },
+    resolveSieges: ({ G, playerID }) => {
+      if (!ensureStage(G, 'siegeResolution')) return INVALID_MOVE;
+      const result = resolveSiegesForPlayer(toDomainState(G), playerID);
+      if (!result.ok) return INVALID_MOVE;
+      transitionStage(G, 'movement');
+    },
+    moveUnit: ({ G, playerID }, unitId: string, col: number, row: number) => {
+      if (!ensureStage(G, 'movement')) return INVALID_MOVE;
+      const result = moveUnitForPlayer(toDomainState(G), playerID, unitId, { col, row });
+      if (!result.ok) return INVALID_MOVE;
+    },
+    toCombatPhase: ({ G }) => {
+      if (!ensureStage(G, 'movement')) return INVALID_MOVE;
+      transitionStage(G, 'combat');
+    },
+    declareCombat: ({ G, playerID }, attackerCol: number, attackerRow: number, defenderCol: number, defenderRow: number) => {
+      if (!ensureStage(G, 'combat')) return INVALID_MOVE;
+      const result = declareCombatForPlayer(
+        toDomainState(G),
+        playerID,
+        { col: attackerCol, row: attackerRow },
+        { col: defenderCol, row: defenderRow },
+      );
+      if (!result.ok) return INVALID_MOVE;
+    },
+    resolveCombat: ({ G, playerID }) => {
+      if (!ensureStage(G, 'combat')) return INVALID_MOVE;
+      const result = resolveNextCombatForPlayer(toDomainState(G), playerID);
+      if (!result.ok) return INVALID_MOVE;
+    },
+    endTurn: ({ G, ctx }) => {
+      if (!ensureStage(G, 'combat')) return INVALID_MOVE;
+      const ctxEvents = (ctx as typeof ctx & { events?: { endTurn?: () => void } }).events;
+      if (ctxEvents?.endTurn) {
+        ctxEvents.endTurn();
+      }
+    },
+  },
+  turn: {
+    order: TurnOrder.DEFAULT,
+    onBegin: ({ G, ctx }) => {
+      G.currentTurn = ctx.turn;
+      G.phase = 'playerTurn';
+      G.stage = 'rollEvents';
+      G.activePlayerIndex = G.turnOrder.indexOf(ctx.currentPlayer);
+      if (G.activePlayerIndex < 0) G.activePlayerIndex = 0;
+      for (const unit of Object.values(G.units)) {
+        if (unit.isAlive) {
+          unit.movementRemaining = unit.movementPoints;
+        }
+      }
+    },
+  },
+  endIf: ({ G }) => {
+    if (G.currentTurn < G.maxTurns) return;
+    const scores = scoreVictoryPointsFromFactionState(toDomainState(G));
+    const ordered = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+    return { winner: ordered[0]?.[0] ?? null, scores };
+  },
+  events: {
+    endTurn: true,
+  },
+  ai: {
+    enumerate: (G, ctx, playerID) => {
+      if (ctx.currentPlayer !== playerID) return [];
+      const stage = G.stage;
+      const domainState = toDomainState(G);
+
+      if (stage === 'rollEvents') return [{ move: 'rollRandomEvent' }];
+      if (stage === 'drawCard') return [{ move: 'drawDiplomacyCard' }];
+      if (stage === 'diplomacy') {
+        const targetFactionId = Object.keys(G.factions).find(
+          (id) => id !== G.players[playerID]?.homeFactionId,
+        );
+        if (!targetFactionId) return [];
+        return [{ move: 'conductDiplomacy', args: [targetFactionId, 'activate'] }];
+      }
+      if (stage === 'siegeResolution') return [{ move: 'resolveSieges' }];
+      if (stage === 'movement') {
+        const movement = findFirstLegalMovement(domainState, playerID);
+        if (movement) {
+          return [
+            {
+              move: 'moveUnit',
+              args: [movement.unitId, movement.destination.col, movement.destination.row],
+            },
+            { move: 'toCombatPhase' },
+          ];
+        }
+        return [{ move: 'toCombatPhase' }];
+      }
+      if (stage === 'combat') {
+        if (hasAnyPendingCombats(domainState)) return [{ move: 'resolveCombat' }, { move: 'endTurn' }];
+        const pair = findFirstCombatPair(domainState, playerID);
+        if (pair) {
+          return [
+            {
+              move: 'declareCombat',
+              args: [pair.attacker.col, pair.attacker.row, pair.defender.col, pair.defender.row],
+            },
+            { move: 'endTurn' },
+          ];
+        }
+        return [{ move: 'endTurn' }];
+      }
+
+      return [];
+    },
+  },
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/app.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/persistence/save-load.test.ts
+++ b/src/persistence/save-load.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { buildInitialGameState } from '@/engine/domain/setup';
+import type { RuntimeGameState } from '@/game/dr3-game';
+import {
+  deleteSave,
+  exportSave,
+  importSave,
+  listSaveMetadata,
+  loadGame,
+  saveGame,
+} from './save-load';
+
+class MemoryStorage {
+  private readonly data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+}
+
+function toRuntimeState(): RuntimeGameState {
+  const fullState = buildInitialGameState({ seed: 'save-seed' });
+  const runtime = Object.fromEntries(
+    Object.entries(fullState).filter(([key]) => key !== 'hexMap'),
+  ) as RuntimeGameState;
+  return runtime;
+}
+
+describe('save-load', () => {
+  it('saves and loads game state for a slot', () => {
+    const storage = new MemoryStorage();
+    const state = toRuntimeState();
+
+    saveGame('slot-a', state, storage);
+    const loaded = loadGame('slot-a', storage);
+
+    expect(loaded).toBeTruthy();
+    expect(loaded?.state.seed).toBe(state.seed);
+  });
+
+  it('exports and imports a save payload', () => {
+    const state = toRuntimeState();
+    const saved = {
+      schemaVersion: 1,
+      savedAtIso: new Date().toISOString(),
+      state,
+    };
+
+    const exported = exportSave(saved);
+    const imported = importSave(exported);
+    expect(imported.state.seed).toBe(state.seed);
+  });
+
+  it('deletes and lists save metadata', () => {
+    const storage = new MemoryStorage();
+    const state = toRuntimeState();
+
+    saveGame('slot-a', state, storage);
+    saveGame('slot-b', state, storage);
+    deleteSave('slot-b', storage);
+
+    const metadata = listSaveMetadata(['slot-a', 'slot-b'], storage);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.slotId).toBe('slot-a');
+  });
+});

--- a/src/persistence/save-load.ts
+++ b/src/persistence/save-load.ts
@@ -1,0 +1,102 @@
+import type { RuntimeGameState } from '@/game/dr3-game';
+
+export const SAVE_SCHEMA_VERSION = 1;
+const SAVE_KEY_PREFIX = 'dr3:save:';
+
+export interface SaveMetadata {
+  slotId: string;
+  schemaVersion: number;
+  savedAtIso: string;
+}
+
+export interface SavedGame {
+  schemaVersion: number;
+  savedAtIso: string;
+  state: RuntimeGameState;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function saveKey(slotId: string): string {
+  return `${SAVE_KEY_PREFIX}${slotId}`;
+}
+
+function assertValidSaveObject(value: unknown): asserts value is SavedGame {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid save payload.');
+  }
+  const candidate = value as Partial<SavedGame>;
+  if (candidate.schemaVersion !== SAVE_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported save schema version ${String(candidate.schemaVersion)}.`,
+    );
+  }
+  if (typeof candidate.savedAtIso !== 'string' || !candidate.state) {
+    throw new Error('Malformed save payload.');
+  }
+}
+
+export function createSaveSnapshot(state: RuntimeGameState): SavedGame {
+  return {
+    schemaVersion: SAVE_SCHEMA_VERSION,
+    savedAtIso: new Date().toISOString(),
+    state,
+  };
+}
+
+export function saveGame(
+  slotId: string,
+  state: RuntimeGameState,
+  storage: StorageLike = localStorage,
+): SavedGame {
+  const snapshot = createSaveSnapshot(state);
+  storage.setItem(saveKey(slotId), JSON.stringify(snapshot));
+  return snapshot;
+}
+
+export function loadGame(
+  slotId: string,
+  storage: StorageLike = localStorage,
+): SavedGame | null {
+  const raw = storage.getItem(saveKey(slotId));
+  if (!raw) return null;
+
+  const parsed = JSON.parse(raw) as unknown;
+  assertValidSaveObject(parsed);
+  return parsed;
+}
+
+export function deleteSave(slotId: string, storage: StorageLike = localStorage): void {
+  storage.removeItem(saveKey(slotId));
+}
+
+export function exportSave(snapshot: SavedGame): string {
+  return JSON.stringify(snapshot, null, 2);
+}
+
+export function importSave(payload: string): SavedGame {
+  const parsed = JSON.parse(payload) as unknown;
+  assertValidSaveObject(parsed);
+  return parsed;
+}
+
+export function listSaveMetadata(
+  slotIds: string[],
+  storage: StorageLike = localStorage,
+): SaveMetadata[] {
+  const metadata: SaveMetadata[] = [];
+  for (const slotId of slotIds) {
+    const saved = loadGame(slotId, storage);
+    if (!saved) continue;
+    metadata.push({
+      slotId,
+      schemaVersion: saved.schemaVersion,
+      savedAtIso: saved.savedAtIso,
+    });
+  }
+  return metadata;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,201 @@
+:root {
+  --bg-top: #15232f;
+  --bg-bottom: #10161d;
+  --panel: #1c2f3b;
+  --panel-muted: #273f4d;
+  --ink: #f1ede0;
+  --ink-muted: #b7c4c7;
+  --accent: #d2843a;
+  --accent-2: #4bb0a7;
+  --danger: #c35a46;
+  --border: #365668;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 15% 15%, rgb(210 132 58 / 16%), transparent 38%),
+    radial-gradient(circle at 85% 10%, rgb(75 176 167 / 14%), transparent 42%),
+    linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
+}
+
+.app-root {
+  margin: 0 auto;
+  max-width: 1400px;
+  padding: 1rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-family: 'Palatino Linotype', 'Book Antiqua', serif;
+  letter-spacing: 0.04em;
+}
+
+.app-header p {
+  margin: 0.25rem 0 1rem;
+  color: var(--ink-muted);
+}
+
+.layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+.board-shell {
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #122028;
+  min-height: 70vh;
+}
+
+.board-svg {
+  width: 100%;
+  min-width: 840px;
+  display: block;
+}
+
+.board-backdrop {
+  fill: #0f1a22;
+}
+
+.hex {
+  stroke: rgb(12 18 22 / 70%);
+  stroke-width: 1;
+  cursor: pointer;
+  transition: fill 120ms ease;
+}
+
+.hex:hover {
+  fill: #d2843a;
+}
+
+.unit-stack {
+  cursor: pointer;
+}
+
+.unit-friendly {
+  fill: var(--accent-2);
+  stroke: #0d332f;
+  stroke-width: 2;
+}
+
+.unit-hostile {
+  fill: var(--danger);
+  stroke: #2f1010;
+  stroke-width: 2;
+}
+
+.unit-label {
+  fill: #fff;
+  font-size: 8px;
+  text-anchor: middle;
+  user-select: none;
+  pointer-events: none;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: linear-gradient(165deg, var(--panel), var(--panel-muted));
+  padding: 0.75rem;
+}
+
+.panel h2 {
+  margin: 0 0 0.5rem;
+  font-family: 'Palatino Linotype', 'Book Antiqua', serif;
+  font-size: 1rem;
+}
+
+.kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0.2rem 0;
+}
+
+.kv span {
+  color: var(--ink-muted);
+}
+
+.status {
+  margin-top: 0.4rem;
+  color: var(--accent);
+}
+
+.actions {
+  display: grid;
+  gap: 0.45rem;
+}
+
+button,
+.file-label {
+  border: 1px solid var(--border);
+  background: #1a2b36;
+  color: var(--ink);
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.88rem;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.file-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.file-label input {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.selection .kv strong {
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.muted {
+  margin: 0;
+  color: var(--ink-muted);
+}
+
+.turn-log {
+  margin: 0;
+  padding-left: 1rem;
+  max-height: 180px;
+  overflow: auto;
+  font-family: 'Courier New', monospace;
+  font-size: 0.78rem;
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .board-shell {
+    min-height: 58vh;
+  }
+}

--- a/src/test/e2e/app.spec.ts
+++ b/src/test/e2e/app.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('starts game and shows initial stage', async ({ page }) => {
+  await expect(page.getByRole('heading', { name: 'Divine Right 3' })).toBeVisible();
+  await expect(page.getByTestId('stage-value')).toHaveText('rollEvents');
+});
+
+test('progresses through a basic turn flow', async ({ page }) => {
+  await page.getByTestId('btn-roll-event').click();
+  await expect(page.getByTestId('stage-value')).toHaveText('drawCard');
+
+  await page.getByTestId('btn-draw-card').click();
+  await expect(page.getByTestId('stage-value')).toHaveText('diplomacy');
+
+  await page.getByTestId('btn-diplomacy').click();
+  await expect(page.getByTestId('stage-value')).toHaveText('siegeResolution');
+
+  await page.getByTestId('btn-resolve-sieges').click();
+  await expect(page.getByTestId('stage-value')).toHaveText('movement');
+
+  await page.getByTestId('btn-to-combat').click();
+  await expect(page.getByTestId('stage-value')).toHaveText('combat');
+});
+
+test('saves and loads from slot-a', async ({ page }) => {
+  await page.getByTestId('btn-save').click();
+  await expect(page.getByTestId('status-text')).toContainText('Saved');
+
+  await page.getByTestId('btn-load').click();
+  await expect(page.getByTestId('status-text')).toContainText('Loaded');
+});
+
+test('runs cpu action sequence', async ({ page }) => {
+  await page.getByTestId('btn-run-cpu').click();
+  await expect(page.getByTestId('status-text')).toContainText('CPU executed');
+});

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,5 +1,12 @@
 export type EventType =
   | 'no_event'
+  | 'untimely_death'
+  | 'storms'
+  | 'mutiny'
+  | 'bad_omens'
+  | 'replacements'
+  | 'desertion'
+  | 'help_from_afar'
   | 'plague'
   | 'famine'
   | 'rebellion'

--- a/src/types/unit.ts
+++ b/src/types/unit.ts
@@ -1,6 +1,14 @@
 import type { HexCoord } from './hex';
 
-export type UnitType = 'monarch' | 'ambassador' | 'army' | 'fleet';
+export type UnitType =
+  | 'monarch'
+  | 'ambassador'
+  | 'army'
+  | 'fleet'
+  | 'regular_army'
+  | 'regular_fleet'
+  | 'mercenary_army'
+  | 'mercenary_fleet';
 
 export type MovementType = 'standard' | 'teleport' | 'naval';
 

--- a/src/ui/HexBoard.tsx
+++ b/src/ui/HexBoard.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+import type { RuntimeGameState } from '@/game/dr3-game';
+import { hexKey } from '@/types';
+
+interface HexBoardProps {
+  state: RuntimeGameState;
+  hexes: Array<{ col: number; row: number; terrain: string[] }>;
+  currentPlayerId: string;
+  selectedUnitId: string | null;
+  onSelectUnit: (unitId: string) => void;
+  onSelectHex: (col: number, row: number) => void;
+}
+
+const HEX_SIZE = 14;
+const HEX_HEIGHT = Math.sqrt(3) * HEX_SIZE;
+
+function hexCenter(col: number, row: number): { x: number; y: number } {
+  return {
+    x: col * HEX_SIZE * 1.5 + HEX_SIZE + 8,
+    y: row * HEX_HEIGHT + (col % 2 === 1 ? HEX_HEIGHT / 2 : 0) + HEX_HEIGHT / 2 + 8,
+  };
+}
+
+function polygonPoints(col: number, row: number): string {
+  const center = hexCenter(col, row);
+  const points: string[] = [];
+  for (let i = 0; i < 6; i += 1) {
+    const angle = (Math.PI / 180) * (60 * i - 30);
+    const x = center.x + HEX_SIZE * Math.cos(angle);
+    const y = center.y + HEX_SIZE * Math.sin(angle);
+    points.push(`${x},${y}`);
+  }
+  return points.join(' ');
+}
+
+function terrainColor(terrain: string[]): string {
+  if (terrain.includes('mountain')) return '#6f7f85';
+  if (terrain.includes('forest')) return '#4f7a56';
+  if (terrain.includes('hill')) return '#9a8e67';
+  if (terrain.includes('sea')) return '#1f5070';
+  if (terrain.includes('seashore')) return '#2c6f78';
+  if (terrain.includes('swamp')) return '#5c6a3a';
+  if (terrain.includes('castle')) return '#8e4f37';
+  return '#7f7259';
+}
+
+export default function HexBoard({
+  state,
+  hexes,
+  currentPlayerId,
+  selectedUnitId,
+  onSelectUnit,
+  onSelectHex,
+}: HexBoardProps) {
+  const unitsByHex = useMemo(() => {
+    const byHex = new Map<
+      string,
+      { count: number; friendly: boolean; unitIds: string[] }
+    >();
+    const playerHomeFaction = state.players[currentPlayerId]?.homeFactionId;
+    for (const unit of Object.values(state.units)) {
+      if (!unit.isAlive) continue;
+      const key = hexKey(unit.position.col, unit.position.row);
+      const entry = byHex.get(key) ?? {
+        count: 0,
+        friendly: unit.factionId === playerHomeFaction,
+        unitIds: [],
+      };
+      entry.count += unit.count;
+      entry.unitIds.push(unit.id);
+      byHex.set(key, entry);
+    }
+    return byHex;
+  }, [state.units, state.players, currentPlayerId]);
+
+  return (
+    <div className="board-shell" data-testid="board-shell">
+      <svg className="board-svg" viewBox="0 0 860 740" role="img" aria-label="DR3 board">
+        <rect x="0" y="0" width="860" height="740" className="board-backdrop" />
+        {hexes.map((hex) => {
+          const key = hexKey(hex.col, hex.row);
+          return (
+            <polygon
+              key={key}
+              points={polygonPoints(hex.col, hex.row)}
+              fill={terrainColor(hex.terrain)}
+              className="hex"
+              onClick={() => onSelectHex(hex.col, hex.row)}
+            />
+          );
+        })}
+        {Array.from(unitsByHex.entries()).map(([key, value]) => {
+          const [colRaw, rowRaw] = key.split(',');
+          const col = Number(colRaw);
+          const row = Number(rowRaw);
+          const center = hexCenter(col, row);
+          const primaryUnitId = value.unitIds[0] ?? '';
+          const selected = primaryUnitId === selectedUnitId;
+          return (
+            <g
+              key={`unit-${key}`}
+              className="unit-stack"
+              onClick={() => onSelectUnit(primaryUnitId)}
+            >
+              <circle
+                cx={center.x}
+                cy={center.y}
+                r={selected ? 8 : 6}
+                className={value.friendly ? 'unit-friendly' : 'unit-hostile'}
+              />
+              <text x={center.x} y={center.y + 3} className="unit-label">
+                {value.count}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add deterministic runtime domain layer and oardgame.io game wrapper
- add React/Vite app shell with SVG board, action sidebar, save/load/import/export, and CPU action trigger
- add persistence and CPU bot modules with tests
- add Playwright E2E coverage for start flow, turn progression, save/load, and CPU action
- add CI workflow covering lint, unit/conformance tests, conformance fixture validation, Playwright, and build
- add GitHub Pages deploy workflow gated by successful CI
- add MCP Playwright config and tooling documentation
- persist updated execution plan in docs/plans/2026-02-09-prd-execution-plan.md

## Verification
- 
pm run lint
- 
pm test
- python3 scripts/validate_conformance_suite.py
- 
pm run test:e2e -- --project=chromium
- 
pm run test:e2e -- --project=ios-safari
- 
pm run build
