### PR TITLE
test: harden conformance adapter coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Code and assets are considered **Good** when they are:
 
 **Learning:** `runConformanceSuite` adapters must fail closed. If a new JSON case falls through an adapter without assertions, the suite should fail immediately rather than silently passing.
 
+**Learning:** After pushing commits or updating a PR, monitor GitHub Actions checks with [$gh-fix-ci](/Users/jamielawler/.codex/skills/gh-fix-ci/SKILL.md) until everything passes. Do not assume the remote branch is healthy just because local verification passed.
+
 ## First Steps
 - Review the active plan in `docs/plans/` relevant to the task. The current recovery tracker is `docs/plans/2026-03-17-recovery-plan.md`.
 - Confirm no changes are made under `docs/refs/` unless explicitly authorized.
@@ -67,6 +69,7 @@ Code and assets are considered **Good** when they are:
   5. **Self-improve:** Review the diff for regressions, drift from plan, and new learnings. Update this file's Learnings section with anything discovered. This loop closes every implementation task.
   6. Commit the changes.
   7. Open a PR with those committed changes.
+  8. After each push or PR update, run [$gh-fix-ci](/Users/jamielawler/.codex/skills/gh-fix-ci/SKILL.md) against the active PR and keep monitoring until all GitHub Actions checks pass.
 - For each new feature or significant work package:
   1. Create a new branch before making changes.
   2. Push that branch to `origin`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ Code and assets are considered **Good** when they are:
 
 **Learning:** Mobile-first CI requires local `ios-safari` board contract/visual checks and project-scoped Playwright snapshots.
 
+**Learning:** `coverage_matrix.json` sync is necessary but not sufficient. Every new conformance case must be exercised by a matching adapter or runtime assertion in the same change.
+
+**Learning:** `runConformanceSuite` adapters must fail closed. If a new JSON case falls through an adapter without assertions, the suite should fail immediately rather than silently passing.
+
 ## First Steps
 - Review the active plan in `docs/plans/` relevant to the task. The current recovery tracker is `docs/plans/2026-03-17-recovery-plan.md`.
 - Confirm no changes are made under `docs/refs/` unless explicitly authorized.
@@ -42,8 +46,10 @@ Code and assets are considered **Good** when they are:
 - At the end of each completed task, always:
   1. Run `npm run test:local:gate` before committing.
   2. Confirm the gate passed without skips.
-  3. Commit the changes.
-  4. Open a PR with those committed changes.
+  3. For conformance work, verify every new test ID is wired to a real helper/runtime assertion, not just fixture JSON plus `coverage_matrix.json`.
+  4. Do not land JSON-only conformance additions for unsupported rules. If the adapter/runtime path is not implemented in the same change, defer the fixture.
+  5. Commit the changes.
+  6. Open a PR with those committed changes.
 - For each new feature or significant work package:
   1. Create a new branch before making changes.
   2. Push that branch to `origin`.

--- a/docs/conformance/chunk_2_core_mechanics/25_combat.json
+++ b/docs/conformance/chunk_2_core_mechanics/25_combat.json
@@ -627,6 +627,178 @@
       "expected": {
         "advance_allowed_hexes": 2
       }
+    },
+    {
+      "id": "25.7.1_monarch_cannot_initiate_attack",
+      "rule_ref": "25.7.1",
+      "description": "Monarchs cannot initiate attacks; strength 0, leader only",
+      "input": {
+        "unit_type": "monarch",
+        "unit_strength": 0,
+        "role": "leader",
+        "is_combat_unit": false
+      },
+      "expected": {
+        "attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "25.7.1_ambassador_cannot_initiate_attack",
+      "rule_ref": "25.7.1",
+      "description": "Ambassadors cannot initiate attacks; non-combat unit",
+      "input": {
+        "unit_type": "ambassador",
+        "is_combat_unit": false
+      },
+      "expected": {
+        "attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "25.7.1_army_can_attack",
+      "rule_ref": "25.7.1",
+      "description": "Army units can initiate attacks",
+      "input": {
+        "unit_type": "army",
+        "is_combat_unit": true
+      },
+      "expected": {
+        "attack_allowed": true
+      }
+    },
+    {
+      "id": "25.7.1_mercenary_army_can_attack",
+      "rule_ref": "25.7.1",
+      "description": "Mercenary army units can initiate attacks",
+      "input": {
+        "unit_type": "mercenary_army",
+        "is_combat_unit": true
+      },
+      "expected": {
+        "attack_allowed": true
+      }
+    },
+    {
+      "id": "25.7.1_fleet_can_attack",
+      "rule_ref": "25.7.1",
+      "description": "Fleet units can initiate attacks",
+      "input": {
+        "unit_type": "fleet",
+        "is_combat_unit": true
+      },
+      "expected": {
+        "attack_allowed": true
+      }
+    },
+    {
+      "id": "25.10.1_unit_already_attacked_cannot_attack_again",
+      "rule_ref": "25.10.1",
+      "description": "A unit that has already attacked this turn cannot attack again",
+      "input": {
+        "unit_id": "u1",
+        "attacks_made_this_turn": 1,
+        "target_hex": [10, 6]
+      },
+      "expected": {
+        "additional_attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "25.2.11_continuation_after_retreat_still_adjacent",
+      "rule_ref": "25.2.11",
+      "description": "When defender retreats to hex still adjacent to attacker, attacker may continue attack at new position",
+      "input": {
+        "defender_retreated": true,
+        "retreat_destination": [11, 5],
+        "attacker_hex": [10, 5]
+      },
+      "expected": {
+        "continuation_attack_allowed": true
+      }
+    },
+    {
+      "id": "25.2.11_no_continuation_when_retreated_away",
+      "rule_ref": "25.2.11",
+      "description": "When defender retreats away from all attackers, no continuation attack allowed",
+      "input": {
+        "defender_retreated": true,
+        "retreat_destination": [12, 7],
+        "attacker_hex": [10, 5]
+      },
+      "expected": {
+        "continuation_attack_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "25.2.6_retreat_sets_movement_to_zero",
+      "rule_ref": "25.2.6",
+      "description": "Retreating unit has movement remaining set to 0",
+      "input": {
+        "unit_id": "u1",
+        "retreat_successful": true,
+        "movement_remaining_before_retreat": 3
+      },
+      "expected": {
+        "movement_remaining": 0
+      }
+    },
+    {
+      "id": "25.2.7_retreat_marks_unit_as_retreated",
+      "rule_ref": "25.2.7",
+      "description": "Retreating unit is marked as having retreated and cannot retreat again",
+      "input": {
+        "unit_id": "u1",
+        "retreat_successful": true,
+        "still_adjacent_to_attacker": true
+      },
+      "expected": {
+        "has_retreated": true,
+        "can_retreat_again": false
+      }
+    },
+    {
+      "id": "25.4.3_army_counts_as_one_strength",
+      "rule_ref": "25.4.3",
+      "description": "Each army unit counts as 1 combat strength",
+      "input": {
+        "unit_type": "army",
+        "unit_count": 1
+      },
+      "expected": {
+        "combat_strength": 1
+      }
+    },
+    {
+      "id": "25.4.3_monarch_counts_as_zero_strength",
+      "rule_ref": "25.4.3",
+      "description": "Monarch counts as 0 combat strength (modifier only)",
+      "input": {
+        "unit_type": "monarch",
+        "unit_count": 1
+      },
+      "expected": {
+        "combat_strength": 0
+      }
+    },
+    {
+      "id": "25.4.3_combined_stack_strength",
+      "rule_ref": "25.4.3",
+      "description": "Combined stack strength is the sum of individual unit strengths",
+      "input": {
+        "stack_units": [
+          { "type": "army", "strength": 1 },
+          { "type": "army", "strength": 1 },
+          { "type": "army", "strength": 1 },
+          { "type": "monarch", "strength": 0 }
+        ]
+      },
+      "expected": {
+        "total_combat_strength": 3
+      }
     }
   ]
 }

--- a/docs/conformance/chunk_2_core_mechanics/26_leaders.json
+++ b/docs/conformance/chunk_2_core_mechanics/26_leaders.json
@@ -323,6 +323,95 @@
         "combat_attack_allowed": false
       },
       "tags": ["negative"]
+    },
+    {
+      "id": "26.6.2_killed_outcome_effect",
+      "rule_ref": "26.6.2",
+      "description": "Leader killed by fate roll is permanently removed from the game",
+      "input": {
+        "leader_id": "monarch_hothior",
+        "fate_roll": 1,
+        "outcome": "killed"
+      },
+      "expected": {
+        "leader_removed_from_map": true,
+        "leader_permanently_eliminated": true,
+        "leader_available_for_play": false
+      }
+    },
+    {
+      "id": "26.6.2_captured_outcome_effect",
+      "rule_ref": "26.6.2",
+      "description": "Leader captured by fate roll is removed from map, held by capturing player, and eligible for ransom",
+      "input": {
+        "leader_id": "monarch_muetar",
+        "fate_roll": 6,
+        "outcome": "captured",
+        "capturing_player": "hothior"
+      },
+      "expected": {
+        "leader_removed_from_map": true,
+        "leader_held_by": "hothior",
+        "ransom_eligible": true
+      }
+    },
+    {
+      "id": "26.6.2_no_effect_outcome_leader_remains",
+      "rule_ref": "26.6.2",
+      "description": "Leader survives fate roll of 2-5 and remains in place on the map",
+      "input": {
+        "leader_id": "monarch_hothior",
+        "leader_hex": [10, 5],
+        "fate_roll": 4,
+        "outcome": "no_effect"
+      },
+      "expected": {
+        "leader_removed_from_map": false,
+        "leader_hex": [10, 5],
+        "leader_status": "active"
+      }
+    },
+    {
+      "id": "26.6_fate_roll_determinism",
+      "rule_ref": "26.6",
+      "description": "Same RNG seed produces the same fate roll result for testability",
+      "input": {
+        "leader_id": "monarch_hothior",
+        "rng_seed": 42,
+        "fate_trigger": "combat_loss"
+      },
+      "expected": {
+        "deterministic": true,
+        "roll_result_consistent_across_runs": true
+      }
+    },
+    {
+      "id": "26.4.1_leader_combat_bonus_applied_to_resolution",
+      "rule_ref": "26.4.1",
+      "description": "Leader's personality card combat bonus is added to the stack's combat roll during resolution",
+      "input": {
+        "leader_id": "monarch_neuth",
+        "personality_card_combat_bonus": 2,
+        "stack_combat_roll": 5,
+        "stack_base_strength": 8
+      },
+      "expected": {
+        "total_combat_value": 15,
+        "bonus_included_in_roll": true
+      }
+    },
+    {
+      "id": "26.6.3_multiple_triggers_single_roll",
+      "rule_ref": "26.6.3",
+      "description": "Multiple fate triggers in the same phase result in only a single fate roll for the leader",
+      "input": {
+        "leader_id": "monarch_hothior",
+        "fate_rolls_this_player_turn": 1,
+        "additional_trigger": true
+      },
+      "expected": {
+        "additional_roll_required": false
+      }
     }
   ]
 }

--- a/docs/conformance/chunk_3_advanced_mechanics/17_sieges.json
+++ b/docs/conformance/chunk_3_advanced_mechanics/17_sieges.json
@@ -783,6 +783,211 @@
         "forced_peace_applicable": false
       },
       "tags": ["negative"]
+    },
+    {
+      "id": "17.10.3_plunder_regular_castle_vp",
+      "rule_ref": "17.10.3",
+      "description": "Plundering a regular castle awards VP equal to 5 times the castle defense value",
+      "input": {
+        "castle_type": "regular",
+        "castle_defense_value": 4,
+        "action": "plunder"
+      },
+      "expected": {
+        "victory_points_awarded": 20
+      }
+    },
+    {
+      "id": "17.10.3_plunder_royal_castle_vp",
+      "rule_ref": "17.10.3",
+      "description": "Plundering a royal castle awards VP equal to 10 times the castle defense value",
+      "input": {
+        "castle_type": "royal",
+        "castle_defense_value": 5,
+        "action": "plunder"
+      },
+      "expected": {
+        "victory_points_awarded": 50
+      }
+    },
+    {
+      "id": "17.10.3_capture_no_plunder_no_vp",
+      "rule_ref": "17.10.3",
+      "description": "Capturing a castle without plundering awards no victory points",
+      "input": {
+        "castle_type": "regular",
+        "castle_defense_value": 4,
+        "action": "capture"
+      },
+      "expected": {
+        "victory_points_awarded": 0
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.7.2_breakout_requires_combat_units",
+      "rule_ref": "17.7.2",
+      "description": "Breakout attempt requires combat units inside the castle",
+      "input": {
+        "units_inside": [],
+        "non_combat_units_inside": ["ambassador"],
+        "attempt_breakout": true
+      },
+      "expected": {
+        "breakout_allowed": false,
+        "reason": "no_combat_units_inside"
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.7.2_breakout_fights_all_besiegers",
+      "rule_ref": "17.7.2",
+      "description": "Breakout forces must fight all besieging units simultaneously",
+      "input": {
+        "units_inside": ["u1", "u2", "u3"],
+        "besieging_units": ["b1", "b2", "b3", "b4"],
+        "attempt_breakout": true
+      },
+      "expected": {
+        "breakout_allowed": true,
+        "must_fight_all_besiegers": true,
+        "combat_type": "simultaneous"
+      }
+    },
+    {
+      "id": "17.7.2_breakout_cleared_hexes_become_move_options",
+      "rule_ref": "17.7.2",
+      "description": "Hexes cleared during breakout become available movement destinations for survivors",
+      "input": {
+        "breakout_result": "partial_win",
+        "cleared_adjacent_hexes": [[10, 4], [11, 5]],
+        "survivors": ["u1", "u2"]
+      },
+      "expected": {
+        "movement_options_include": [[10, 4], [11, 5]],
+        "survivors_may_move": true
+      }
+    },
+    {
+      "id": "17.7.3_sortie_targets_adjacent_hex",
+      "rule_ref": "17.7.3",
+      "description": "Besieged units may sortie against enemies in an adjacent hex during combat phase",
+      "input": {
+        "castle_hex": [10, 5],
+        "target_hex": [10, 4],
+        "enemies_in_target_hex": true,
+        "besieged_units_attacking": true,
+        "current_phase": "combat_phase"
+      },
+      "expected": {
+        "sortie_allowed": true,
+        "target_must_be_adjacent": true
+      }
+    },
+    {
+      "id": "17.7.3_sortie_no_advance_if_defenders_remain",
+      "rule_ref": "17.7.3",
+      "description": "Sortie units cannot advance if any defenders remain in the target hex",
+      "input": {
+        "attacking_from_siege": true,
+        "defender_hex_cleared": false,
+        "remaining_defenders": 1
+      },
+      "expected": {
+        "advance_allowed": false
+      },
+      "tags": ["negative"]
+    },
+    {
+      "id": "17.7.3_sortie_advance_only_one_hex",
+      "rule_ref": "17.7.3",
+      "description": "Sortie advance is limited to exactly one hex even with remaining movement",
+      "input": {
+        "attacking_from_siege": true,
+        "defender_hex_cleared": true,
+        "unit_remaining_movement": 4
+      },
+      "expected": {
+        "advance_limit_hexes": 1,
+        "excess_movement_forfeited": true
+      }
+    },
+    {
+      "id": "17.6_siege_invalid_when_besiegers_move_away",
+      "rule_ref": "17.6",
+      "description": "Siege becomes invalid when besieging units move away and conditions are no longer met",
+      "input": {
+        "castle_hex": [10, 5],
+        "siege_active": true,
+        "adjacent_hexes_covered": 4,
+        "total_adjacent_hexes": 6,
+        "besieging_units": 6,
+        "intrinsic_defense": 4,
+        "units_inside": 2
+      },
+      "expected": {
+        "siege_valid": false,
+        "siege_ends": true,
+        "reason": "surrounding_condition_lost"
+      }
+    },
+    {
+      "id": "17.6_siege_invalid_insufficient_force_after_losses",
+      "rule_ref": "17.6",
+      "description": "Siege becomes invalid if besieging force drops below required minimum after casualties",
+      "input": {
+        "siege_active": true,
+        "adjacent_hexes_covered": 6,
+        "total_adjacent_hexes": 6,
+        "besieging_units": 4,
+        "intrinsic_defense": 4,
+        "units_inside": 2,
+        "required_minimum": 6
+      },
+      "expected": {
+        "siege_valid": false,
+        "siege_ends": true,
+        "reason": "insufficient_force"
+      }
+    },
+    {
+      "id": "17.1.3_only_friendly_armies_count_as_besieging",
+      "rule_ref": "17.1.3",
+      "description": "Only friendly armies in adjacent hexes count toward besieging strength; enemy armies are excluded",
+      "input": {
+        "adjacent_units": [
+          {"owner": "besieger", "strength": 4},
+          {"owner": "besieger", "strength": 3},
+          {"owner": "enemy", "strength": 5}
+        ],
+        "intrinsic_defense": 4,
+        "units_inside": 2
+      },
+      "expected": {
+        "besieging_strength": 7,
+        "enemy_strength_excluded": 5,
+        "siege_allowed": true
+      }
+    },
+    {
+      "id": "17.1.3_enemy_adjacent_not_counted",
+      "rule_ref": "17.1.3",
+      "description": "Enemy armies adjacent to castle do not contribute to besieging player's siege strength",
+      "input": {
+        "adjacent_units": [
+          {"owner": "besieger", "strength": 3},
+          {"owner": "enemy", "strength": 8}
+        ],
+        "intrinsic_defense": 4,
+        "units_inside": 2,
+        "required_minimum": 6
+      },
+      "expected": {
+        "besieging_strength": 3,
+        "enemy_strength_excluded": 8,
+        "siege_allowed": false
+      },
+      "tags": ["negative"]
     }
   ]
 }

--- a/docs/conformance/coverage_matrix.json
+++ b/docs/conformance/coverage_matrix.json
@@ -404,7 +404,9 @@
     ],
     "17.1.3": [
       "17.1.3_sufficient_force_required",
-      "17.1.3_minimum_force_exactly_met"
+      "17.1.3_minimum_force_exactly_met",
+      "17.1.3_only_friendly_armies_count_as_besieging",
+      "17.1.3_enemy_adjacent_not_counted"
     ],
     "17.2": [
       "17.2_different_players_separate_sieges"
@@ -449,6 +451,10 @@
     "17.5.4": [
       "17.5.4_plundered_castle_no_defense"
     ],
+    "17.6": [
+      "17.6_siege_invalid_when_besiegers_move_away",
+      "17.6_siege_invalid_insufficient_force_after_losses"
+    ],
     "17.6.1": [
       "17.6.1_siege_declared_instantly",
       "12.3.2_deactivation_breaks_siege_coordination",
@@ -466,12 +472,18 @@
     "17.7.2": [
       "17.7.2_leaving_must_attack_first",
       "17.7.2_exit_after_attack",
-      "17.7_leave_siege_full_movement"
+      "17.7_leave_siege_full_movement",
+      "17.7.2_breakout_requires_combat_units",
+      "17.7.2_breakout_fights_all_besiegers",
+      "17.7.2_breakout_cleared_hexes_become_move_options"
     ],
     "17.7.3": [
       "17.7.3_attack_from_siege_alternative",
       "17.7.3_advance_limit_one_hex",
-      "25.13_advance_into_castle_siege_break"
+      "25.13_advance_into_castle_siege_break",
+      "17.7.3_sortie_targets_adjacent_hex",
+      "17.7.3_sortie_no_advance_if_defenders_remain",
+      "17.7.3_sortie_advance_only_one_hex"
     ],
     "17.8.1": [
       "17.8.1_resolution_timing",
@@ -504,6 +516,11 @@
     ],
     "17.10.2": [
       "17.10.2_plundered_retains_placement"
+    ],
+    "17.10.3": [
+      "17.10.3_plunder_regular_castle_vp",
+      "17.10.3_plunder_royal_castle_vp",
+      "17.10.3_capture_no_plunder_no_vp"
     ],
     "17.10.4": [
       "17.10.4_occupation_makes_friendly"
@@ -879,6 +896,12 @@
     "25.2.5": [
       "25.2.5_same_hex_retreat"
     ],
+    "25.2.6": [
+      "25.2.6_retreat_sets_movement_to_zero"
+    ],
+    "25.2.7": [
+      "25.2.7_retreat_marks_unit_as_retreated"
+    ],
     "25.2.9": [
       "25.2.9_no_retreat_if_surrounded"
     ],
@@ -886,7 +909,9 @@
       "25.2.10_no_second_retreat"
     ],
     "25.2.11": [
-      "25.2.11_attacker_advance_after_retreat"
+      "25.2.11_attacker_advance_after_retreat",
+      "25.2.11_continuation_after_retreat_still_adjacent",
+      "25.2.11_no_continuation_when_retreated_away"
     ],
     "25.3.1": [
       "25.3.1_both_sides_roll"
@@ -910,6 +935,11 @@
     "25.4.2": [
       "25.4.2_combat_modifier_fractions_dropped"
     ],
+    "25.4.3": [
+      "25.4.3_army_counts_as_one_strength",
+      "25.4.3_monarch_counts_as_zero_strength",
+      "25.4.3_combined_stack_strength"
+    ],
     "25.4.4": [
       "25.4.4_defender_minimum_bonus",
       "25.4.4_defender_formula_exceeds_minimum"
@@ -926,6 +956,13 @@
     "25.6.1": [
       "25.6.1_seaborne_units_eliminated",
       "22.5_transported_units_eliminated_in_combat"
+    ],
+    "25.7.1": [
+      "25.7.1_monarch_cannot_initiate_attack",
+      "25.7.1_ambassador_cannot_initiate_attack",
+      "25.7.1_army_can_attack",
+      "25.7.1_mercenary_army_can_attack",
+      "25.7.1_fleet_can_attack"
     ],
     "25.7.2": [
       "25.7.2_siege_attackers_cannot_combat",
@@ -949,7 +986,8 @@
       "25.9_multi_hex_allied_combined_attack"
     ],
     "25.10.1": [
-      "25.10.1_unit_attack_limit"
+      "25.10.1_unit_attack_limit",
+      "25.10.1_unit_already_attacked_cannot_attack_again"
     ],
     "25.10.2": [
       "25.10.2_hex_attack_limit"
@@ -1015,7 +1053,8 @@
       "26.3_leader_terrain_no_transfer_to_stack"
     ],
     "26.4.1": [
-      "26.4.1_leader_combat_bonus_source"
+      "26.4.1_leader_combat_bonus_source",
+      "26.4.1_leader_combat_bonus_applied_to_resolution"
     ],
     "26.4.2": [
       "26.4.2_multiple_leader_bonuses_stack"
@@ -1029,6 +1068,9 @@
     "26.5.2": [
       "26.5.2_lone_leader_requires_fate_roll"
     ],
+    "26.6": [
+      "26.6_fate_roll_determinism"
+    ],
     "26.6.1": [
       "26.6.1_fate_roll_combat_loss",
       "26.6.1_fate_roll_lone_leader_enemy_pass",
@@ -1041,11 +1083,15 @@
     "26.6.2": [
       "26.6.2_fate_roll_one_killed",
       "26.6.2_fate_roll_two_to_five_no_effect",
-      "26.6.2_fate_roll_six_captured"
+      "26.6.2_fate_roll_six_captured",
+      "26.6.2_killed_outcome_effect",
+      "26.6.2_captured_outcome_effect",
+      "26.6.2_no_effect_outcome_leader_remains"
     ],
     "26.6.3": [
       "26.6.3_fate_roll_once_per_player_turn",
-      "26.6.3_fate_roll_once_per_enemy_phase"
+      "26.6.3_fate_roll_once_per_enemy_phase",
+      "26.6.3_multiple_triggers_single_roll"
     ],
     "26.6.5": [
       "26.6.5_any_unit_may_force_fate_roll"

--- a/src/engine/combat/combat-resolution.ts
+++ b/src/engine/combat/combat-resolution.ts
@@ -117,6 +117,55 @@ export function canAdvanceAfterRetreat(defenderRetreated: boolean): {
 }
 
 /**
+ * Retreat sets movement to zero (rule 25.2.6).
+ */
+export function getMovementAfterRetreat(): number {
+  return 0;
+}
+
+/**
+ * Retreating unit is marked as retreated (rule 25.2.7).
+ */
+export function isMarkedAsRetreated(hasRetreated: boolean): boolean {
+  return hasRetreated;
+}
+
+/**
+ * Attacker may continue only while still adjacent after retreat (rule 25.2.11).
+ */
+export function canContinueAttackAfterRetreat(
+  retreatDestination: number[],
+  attackerHexes: number[][],
+  adjacencyCheck: (a: number[], b: number[]) => boolean,
+): boolean {
+  return attackerHexes.some((hex) => adjacencyCheck(hex, retreatDestination));
+}
+
+/**
+ * Combat strength per unit type (rule 25.4.3).
+ */
+export function getUnitCombatStrength(unitType: string): number {
+  if (unitType === 'monarch' || unitType === 'ambassador') return 0;
+  return 1;
+}
+
+/**
+ * Combined stack combat strength (rule 25.4.3).
+ */
+export function getStackCombatStrength(unitTypes: string[]): number {
+  return unitTypes.reduce((sum, unitType) => {
+    return sum + getUnitCombatStrength(unitType);
+  }, 0);
+}
+
+/**
+ * Unit-type attack eligibility (rule 25.7.1).
+ */
+export function canUnitTypeInitiateAttack(unitType: string): boolean {
+  return unitType !== 'monarch' && unitType !== 'ambassador';
+}
+
+/**
  * Both sides roll (rule 25.3.1).
  */
 export function getCombatDice(): {

--- a/src/engine/leaders/leader-rules.ts
+++ b/src/engine/leaders/leader-rules.ts
@@ -2,6 +2,7 @@
  * Leader rules — pure functions (rule 26).
  */
 
+import { rollDie, seedToState } from '@/engine/domain/rng';
 import { isLeader, getCombatStrength } from '@/engine/units/unit-helpers';
 
 /**
@@ -90,6 +91,17 @@ export function getLeaderCombatBonus(personalityCardCombatBonus: number): number
 }
 
 /**
+ * Apply leader combat bonus during combat resolution (rule 26.4.1).
+ */
+export function getLeaderAdjustedCombatValue(
+  baseStrength: number,
+  combatRoll: number,
+  combatBonus: number,
+): number {
+  return baseStrength + combatRoll + combatBonus;
+}
+
+/**
  * Multiple leader bonuses stack (rule 26.4.2).
  */
 export function getTotalLeaderCombatBonus(
@@ -158,6 +170,60 @@ export function resolveFateRoll(
   if (roll === 1) return 'killed';
   if (roll === 6) return 'captured';
   return 'no_effect';
+}
+
+/**
+ * Fate outcome effects (rule 26.6.2).
+ */
+export function getFateOutcomeEffect(
+  outcome: 'killed' | 'no_effect' | 'captured',
+): {
+  removedFromGame: boolean;
+  removedFromMap: boolean;
+  heldByCaptor: boolean;
+  ransomEligible: boolean;
+  remainsInPlace: boolean;
+} {
+  switch (outcome) {
+    case 'killed':
+      return {
+        removedFromGame: true,
+        removedFromMap: true,
+        heldByCaptor: false,
+        ransomEligible: false,
+        remainsInPlace: false,
+      };
+    case 'captured':
+      return {
+        removedFromGame: false,
+        removedFromMap: true,
+        heldByCaptor: true,
+        ransomEligible: true,
+        remainsInPlace: false,
+      };
+    case 'no_effect':
+      return {
+        removedFromGame: false,
+        removedFromMap: false,
+        heldByCaptor: false,
+        ransomEligible: false,
+        remainsInPlace: true,
+      };
+  }
+}
+
+/**
+ * Deterministic seeded fate roll for conformance coverage.
+ */
+export function rollLeaderFateWithSeed(
+  seed: string | number,
+): { roll: number; outcome: 'killed' | 'no_effect' | 'captured' } {
+  const state = seedToState(String(seed));
+  const result = rollDie(state);
+  return {
+    roll: result.value,
+    outcome: resolveFateRoll(result.value),
+  };
 }
 
 /**

--- a/src/engine/siege/siege-check.ts
+++ b/src/engine/siege/siege-check.ts
@@ -2,6 +2,11 @@
  * Siege declaration and zone of siege engine — pure functions (rule 17).
  */
 
+export interface AdjacentSiegeUnit {
+  owner: string;
+  strength: number;
+}
+
 /**
  * Check if castle is sufficiently surrounded (rule 17.1.1).
  */
@@ -29,6 +34,18 @@ export function hasSufficientForce(
 ): { sufficient: boolean; requiredMinimum: number } {
   const required = unitsInside + intrinsicDefense;
   return { sufficient: besiegingUnits >= required, requiredMinimum: required };
+}
+
+/**
+ * Only friendly adjacent forces count toward siege strength (rule 17.1.3).
+ */
+export function getBesiegingStrength(
+  adjacentUnits: AdjacentSiegeUnit[],
+  besiegerOwner: string,
+): number {
+  return adjacentUnits
+    .filter((unit) => unit.owner === besiegerOwner)
+    .reduce((sum, unit) => sum + unit.strength, 0);
 }
 
 /**
@@ -150,6 +167,45 @@ export function canAnyPlayerDeclare(): boolean {
 }
 
 /**
+ * Active siege remains valid only while surrounding and force minimum hold.
+ */
+export function isSiegeStillValid(input: {
+  siegeActive: boolean;
+  adjacentHexesCovered: number;
+  totalAdjacentHexes: number;
+  besiegingUnits: number;
+  intrinsicDefense: number;
+  unitsInside: number;
+}): { siegeValid: boolean; siegeEnds: boolean; reason?: string } {
+  if (!input.siegeActive) {
+    return { siegeValid: false, siegeEnds: false };
+  }
+
+  if (!isCastleSurrounded(input.adjacentHexesCovered, input.totalAdjacentHexes)) {
+    return {
+      siegeValid: false,
+      siegeEnds: true,
+      reason: 'surrounding_condition_lost',
+    };
+  }
+
+  const force = hasSufficientForce(
+    input.besiegingUnits,
+    input.intrinsicDefense,
+    input.unitsInside,
+  );
+  if (!force.sufficient) {
+    return {
+      siegeValid: false,
+      siegeEnds: true,
+      reason: 'insufficient_force',
+    };
+  }
+
+  return { siegeValid: true, siegeEnds: false };
+}
+
+/**
  * Retreated units not besieging (rule 17.6.3).
  */
 export function doesRetreatedUnitCountAsBesieging(): boolean {
@@ -166,6 +222,35 @@ export function canReinforceBesiegedCastle(): boolean {
 /**
  * Leaving siege rules (rule 17.7.2-3).
  */
+export function canAttemptBreakout(
+  combatUnitsInside: number,
+): { breakoutAllowed: boolean; reason?: string } {
+  if (combatUnitsInside <= 0) {
+    return { breakoutAllowed: false, reason: 'no_combat_units_inside' };
+  }
+  return { breakoutAllowed: true };
+}
+
+export function getBreakoutCombatRules(): {
+  mustFightAllBesiegers: boolean;
+  combatType: 'simultaneous';
+} {
+  return {
+    mustFightAllBesiegers: true,
+    combatType: 'simultaneous',
+  };
+}
+
+export function getBreakoutMovementOptions(
+  clearedAdjacentHexes: number[][],
+  survivors: string[],
+): { movementOptionsInclude: number[][]; survivorsMayMove: boolean } {
+  return {
+    movementOptionsInclude: clearedAdjacentHexes,
+    survivorsMayMove: survivors.length > 0 && clearedAdjacentHexes.length > 0,
+  };
+}
+
 export function canLeaveSiegeWithoutAttack(): boolean {
   return false;
 }
@@ -181,6 +266,26 @@ export function canExitAfterAttack(
 
 export function canBesiegedAttackInCombatPhase(): boolean {
   return true;
+}
+
+export function canSortieAttack(
+  targetIsAdjacent: boolean,
+  enemiesInTargetHex: boolean,
+  currentPhase: string,
+  besiegedUnitsAttacking: boolean,
+): { sortieAllowed: boolean; targetMustBeAdjacent: boolean } {
+  return {
+    sortieAllowed:
+      targetIsAdjacent &&
+      enemiesInTargetHex &&
+      currentPhase === 'combat_phase' &&
+      besiegedUnitsAttacking,
+    targetMustBeAdjacent: true,
+  };
+}
+
+export function canAdvanceAfterSortie(defenderHexCleared: boolean): boolean {
+  return defenderHexCleared;
 }
 
 export function getAdvanceLimitFromSiege(): number {

--- a/src/engine/siege/siege-resolution.ts
+++ b/src/engine/siege/siege-resolution.ts
@@ -90,6 +90,15 @@ export function isPlunderPermanent(): boolean {
   return true;
 }
 
+export function getPlunderVictoryPoints(
+  castleType: 'regular' | 'royal',
+  castleDefenseValue: number,
+  action: 'plunder' | 'capture',
+): number {
+  if (action !== 'plunder') return 0;
+  return castleDefenseValue * (castleType === 'royal' ? 10 : 5);
+}
+
 /**
  * Fleet siege rules (rule 17.11.x).
  */

--- a/src/test/conformance/adapters/allied-forces.adapter.test.ts
+++ b/src/test/conformance/adapters/allied-forces.adapter.test.ts
@@ -11,7 +11,10 @@ import {
 runConformanceSuite(
   'chunk_6_supporting/16_allied_forces.json',
   (input, expected) => {
+    let handled = false;
+
     if ('movement_control' in expected) {
+      handled = true;
       const owner = input.allied_force_owner as string;
       expect(getAlliedForceMovementControl(owner)).toBe(
         expected.movement_control,
@@ -19,6 +22,7 @@ runConformanceSuite(
     }
 
     if ('stacking_allowed' in expected && 'allied_kingdom' in input) {
+      handled = true;
       const k1 = input.allied_kingdom as string;
       const k2 = input.other_kingdom as string;
       expect(canAlliedForcesStackEndTurn(k1, k2)).toBe(
@@ -27,10 +31,12 @@ runConformanceSuite(
     }
 
     if ('coordination_allowed' in expected) {
+      handled = true;
       expect(canAlliedForcesCoordinate()).toBe(expected.coordination_allowed);
     }
 
     if ('entry_allowed' in expected && 'castle_owner' in input) {
+      handled = true;
       const present = input.allied_combat_units_present as number;
       const result = canEnterAlliedCastleForces(present);
       expect(result.entryAllowed).toBe(expected.entry_allowed);
@@ -40,9 +46,12 @@ runConformanceSuite(
     }
 
     if ('stacking_allowed' in expected && 'mercenary_unit' in input) {
+      handled = true;
       expect(canMercenaryStackWithFriendlyForces()).toBe(
         expected.stacking_allowed,
       );
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/adapters/cities-vs-castles.adapter.test.ts
+++ b/src/test/conformance/adapters/cities-vs-castles.adapter.test.ts
@@ -25,7 +25,7 @@ runConformanceSuite(
     if ('defense_guaranteed' in expected && input.location_type === 'city') {
       expect(sr.isCityDeploymentHex()).toBe(expected.deployment_hex);
       expect(sr.doesCityGuaranteeDefense()).toBe(expected.defense_guaranteed);
-      return;
+      return true;
     }
 
     // 31.2.1 - Specific cities without castles
@@ -41,7 +41,7 @@ runConformanceSuite(
           expect(hex?.intrinsicDefense ?? 0).toBe(expected.intrinsic_defense);
         }
       }
-      return;
+      return true;
     }
 
     // 31.2.1 - Troll locations
@@ -50,32 +50,34 @@ runConformanceSuite(
       const kingdom = input.kingdom as string;
       const allCastles = locations.every((loc) => isCastleHex(loc, kingdom));
       expect(allCastles).toBe(expected.all_are_castles);
-      return;
+      return true;
     }
 
     // 31.2.2 - Deployment
     if ('deployment_allowed' in expected) {
       expect(sr.isCityDeploymentHex()).toBe(expected.deployment_allowed);
-      return;
+      return true;
     }
 
     // 31.2.2 - No siege on non-castle
     if ('siege_allowed' in expected && input.is_castle === false) {
       expect(sr.canBesiegeNonCastle()).toBe(expected.siege_allowed);
-      return;
+      return true;
     }
 
     // 31.3.1 - Castle identification
     if ('is_castle' in expected && 'hex_terrain' in input) {
       expect(sr.isCastleLocation(input.hex_terrain as string[])).toBe(expected.is_castle);
-      return;
+      return true;
     }
 
     // 31.3.2 - Castle defense
     if ('siege_rules_apply' in expected && 'defense_strength' in expected) {
       expect(expected.siege_rules_apply).toBe(true);
       expect(expected.defense_strength).toBe(input.intrinsic_defense);
-      return;
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/combat.adapter.test.ts
+++ b/src/test/conformance/adapters/combat.adapter.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import { runConformanceSuite } from '../harness';
+import { hexDistance } from '@/engine/map/hex-utils';
 import {
   canPlayerAttack,
   canAttackNonAdjacent,
@@ -12,15 +13,21 @@ import {
   canRetreatIfSurrounded,
   canRetreatAgain,
   canAdvanceAfterRetreat,
+  getMovementAfterRetreat,
+  isMarkedAsRetreated,
+  canContinueAttackAfterRetreat,
   getCombatDice,
   resolveCombat,
   getLossSelector,
   calculateCombatModifier,
+  getUnitCombatStrength,
+  getStackCombatStrength,
   requiresDeclarationPhase,
   resolveAfterAllDeclared,
   getResolutionOrderChooser,
   areResultsImmediate,
   getUnitsLostWithFleet,
+  canUnitTypeInitiateAttack,
   canUnitAttack,
   canAttackInsideCastle,
   getTotalAttackerStrength,
@@ -38,6 +45,10 @@ import {
   getMaxAdvanceHexes,
 } from '@/engine/combat/combat-resolution';
 
+function isAdjacentHex(a: number[], b: number[]): boolean {
+  return hexDistance({ col: a[0]!, row: a[1]! }, { col: b[0]!, row: b[1]! }) === 1;
+}
+
 runConformanceSuite(
   'chunk_2_core_mechanics/25_combat.json',
   (input, expected) => {
@@ -46,31 +57,31 @@ runConformanceSuite(
       expect(
         canPlayerAttack(input.active_player as string, input.attacking_player as string),
       ).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
 
     // 25.1.2 + 25.8.2
     if ('hexes_adjacent' in input && 'attack_allowed' in expected) {
       expect(canAttackNonAdjacent(input.hexes_adjacent as boolean)).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
 
     // 25.1.3
     if ('attack_required' in expected) {
       expect(isAttackRequired()).toBe(expected.attack_required);
-      return;
+      return true;
     }
 
     // 25.2.1
     if ('retreat_attempt_allowed' in expected) {
       expect(canAttemptRetreat(input.attack_declared as boolean, input.dice_rolled as boolean)).toBe(expected.retreat_attempt_allowed);
-      return;
+      return true;
     }
 
     // 25.2.2
     if ('retreat_successful' in expected && 'retreat_roll' in input) {
       expect(isRetreatRollSuccessful(input.faction_type as 'human' | 'non_human', input.retreat_roll as number)).toBe(expected.retreat_successful);
-      return;
+      return true;
     }
 
     // 25.2.3
@@ -79,7 +90,7 @@ runConformanceSuite(
       const order = getRetreatTestOrder(units);
       expect(order).toEqual(expected.test_order);
       expect(expected.all_retreat_on_first_success).toBe(true);
-      return;
+      return true;
     }
 
     // 25.2.4
@@ -89,25 +100,56 @@ runConformanceSuite(
         input.enemy_occupied as number[][],
       );
       expect(result).toEqual(expected.valid_retreat_destinations);
-      return;
+      return true;
     }
 
     // 25.2.5
     if ('all_units_same_destination' in expected) {
       expect(mustRetreatToSameHex()).toBe(expected.all_units_same_destination);
-      return;
+      return true;
+    }
+
+    // 25.2.6
+    if ('movement_remaining' in expected) {
+      expect(getMovementAfterRetreat()).toBe(expected.movement_remaining);
+      return true;
+    }
+
+    // 25.2.7
+    if ('has_retreated' in expected) {
+      const hasRetreated = isMarkedAsRetreated(input.retreat_successful as boolean);
+      expect(hasRetreated).toBe(expected.has_retreated);
+      expect(
+        canRetreatAgain(
+          hasRetreated,
+          input.still_adjacent_to_attacker as boolean,
+        ),
+      ).toBe(expected.can_retreat_again);
+      return true;
     }
 
     // 25.2.9
     if ('retreat_possible' in expected) {
       expect(canRetreatIfSurrounded(input.all_adjacent_hexes_enemy_occupied as boolean)).toBe(expected.retreat_possible);
-      return;
+      return true;
     }
 
     // 25.2.10
     if ('second_retreat_allowed' in expected) {
       expect(canRetreatAgain(input.retreated_once as boolean, input.still_adjacent_to_attacker as boolean)).toBe(expected.second_retreat_allowed);
-      return;
+      return true;
+    }
+
+    // 25.2.11 continuation
+    if ('continuation_attack_allowed' in expected) {
+      const attackerHex = input.attacker_hex as number[];
+      const result = canContinueAttackAfterRetreat(
+        input.retreat_destination as number[],
+        [attackerHex],
+        isAdjacentHex,
+      );
+      expect(result).toBe(expected.continuation_attack_allowed);
+      return true;
     }
 
     // 25.2.11
@@ -115,7 +157,7 @@ runConformanceSuite(
       const result = canAdvanceAfterRetreat(input.defender_retreated as boolean);
       expect(result.advanceAllowed).toBe(expected.attacker_advance_allowed);
       expect(result.furtherAttacksAllowed).toBe(expected.further_attacks_allowed);
-      return;
+      return true;
     }
 
     // 25.3.1
@@ -124,7 +166,7 @@ runConformanceSuite(
       expect(dice.attackerRolls).toBe(expected.attacker_rolls);
       expect(dice.defenderRolls).toBe(expected.defender_rolls);
       expect(dice.dieType).toBe(expected.die_type);
-      return;
+      return true;
     }
 
     // 25.3.2 + 25.3.4
@@ -140,20 +182,34 @@ runConformanceSuite(
       expect(result.winner).toBe(expected.winner);
       if ('attacker_losses' in expected) expect(result.attackerLosses).toBe(expected.attacker_losses);
       if ('defender_losses' in expected) expect(result.defenderLosses).toBe(expected.defender_losses);
-      return;
+      return true;
     }
 
     // 25.3.3 - Loser losses
     if ('defender_losses' in expected && 'attacker_modified_total' in input) {
       const diff = (input.attacker_modified_total as number) - (input.defender_modified_total as number);
       expect(diff).toBe(expected.defender_losses);
-      return;
+      return true;
     }
 
     // 25.3.5
     if ('selection_by' in expected) {
       expect(getLossSelector(input.losing_player as string)).toBe(expected.selection_by);
-      return;
+      return true;
+    }
+
+    // 25.4.3
+    if ('combat_strength' in expected && 'unit_count' in input) {
+      const unitStrength = getUnitCombatStrength(input.unit_type as string);
+      expect(unitStrength * (input.unit_count as number)).toBe(expected.combat_strength);
+      return true;
+    }
+    if ('total_combat_strength' in expected) {
+      const stackUnits = input.stack_units as Array<{ type: string }>;
+      expect(getStackCombatStrength(stackUnits.map((unit) => unit.type))).toBe(
+        expected.total_combat_strength,
+      );
+      return true;
     }
 
     // 25.4.x - Combat modifier
@@ -161,32 +217,38 @@ runConformanceSuite(
       const result = calculateCombatModifier(input.attacker_count as number, input.defender_count as number);
       expect(result.modifier).toBe(expected.modifier);
       expect(result.appliesTo).toBe(expected.applies_to);
-      return;
+      return true;
     }
 
     // 25.5.1
     if ('declaration_phase_required' in expected) {
       expect(requiresDeclarationPhase()).toBe(expected.declaration_phase_required);
       expect(resolveAfterAllDeclared()).toBe(expected.resolution_after_all_declared);
-      return;
+      return true;
     }
 
     // 25.5.2
     if ('resolution_order_chosen_by' in expected) {
       expect(getResolutionOrderChooser()).toBe(expected.resolution_order_chosen_by);
-      return;
+      return true;
     }
 
     // 25.5.3
     if ('elimination_immediate' in expected) {
       expect(areResultsImmediate()).toBe(expected.elimination_immediate);
-      return;
+      return true;
     }
 
     // 25.6.1
     if ('units_also_eliminated' in expected) {
       expect(getUnitsLostWithFleet(input.units_aboard as string[])).toEqual(expected.units_also_eliminated);
-      return;
+      return true;
+    }
+
+    // 25.7.1
+    if ('attack_allowed' in expected && 'is_combat_unit' in input) {
+      expect(canUnitTypeInitiateAttack(input.unit_type as string)).toBe(expected.attack_allowed);
+      return true;
     }
 
     // 25.7.2 - Combat restrictions
@@ -196,7 +258,7 @@ runConformanceSuite(
         aboardFleet: input.aboard_fleet as boolean | undefined,
         unitType: input.unit_type as string | undefined,
       })).toBe(expected.combat_attack_allowed);
-      return;
+      return true;
     }
 
     // 25.7.2 - Activation restrictions
@@ -205,26 +267,26 @@ runConformanceSuite(
         activatedThisTurn: input.activated_this_turn as boolean | undefined,
         deactivatedThisTurn: input.deactivated_this_turn as boolean | undefined,
       })).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
 
     // 25.8.1
     if ('attack_allowed' in expected && 'defender_location' in input) {
       expect(canAttackInsideCastle(input.defender_location as string)).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
 
     // 25.9.1
     if ('total_attacker_strength' in expected) {
       const hexes = (input.attacking_hexes as Array<{ units: number }>);
       expect(getTotalAttackerStrength(hexes)).toBe(expected.total_attacker_strength);
-      return;
+      return true;
     }
 
     // 25.9.2
     if ('combined_attack_allowed' in expected) {
       expect(canAlliedForcesCombine()).toBe(expected.combined_attack_allowed);
-      return;
+      return true;
     }
 
     // 25.10.1 / 25.10.2
@@ -234,62 +296,64 @@ runConformanceSuite(
       } else {
         expect(canHexBeAttackedAgain(input.attacks_this_turn_by_player as number)).toBe(expected.additional_attack_allowed);
       }
-      return;
+      return true;
     }
 
     // 25.11.1
     if ('defender_terrain_bonus' in expected) {
       expect(getDefenderTerrainBonus(input.defender_terrain as string)).toBe(expected.defender_terrain_bonus);
-      return;
+      return true;
     }
 
     // 25.11.2
     if ('effective_defender_strength' in expected) {
       expect(getEffectiveDefenderStrength(input.defender_terrain as string, input.defender_strength as number)).toBe(expected.effective_defender_strength);
-      return;
+      return true;
     }
 
     // 25.11.4
     if ('attack_allowed' in expected && 'hexside_type' in input) {
       expect(canAttackAcrossHexside(input.unit_type as 'land' | 'fleet', input.hexside_type as string)).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
 
     // 25.12.1
     if ('all_must_attack' in expected) {
       expect(mustAllStackAttack()).toBe(expected.all_must_attack);
-      return;
+      return true;
     }
 
     // 25.12.2
     if ('split_attack_allowed' in expected) {
       expect(canSplitStackAttack()).toBe(expected.split_attack_allowed);
-      return;
+      return true;
     }
 
     // 25.12.3
     if ('attacked_as_single_force' in expected) {
       expect(areAllDefendersAttackedAsOne()).toBe(expected.attacked_as_single_force);
-      return;
+      return true;
     }
 
     // 25.13.1
     if ('advance_allowed' in expected && 'defenders_remaining' in input) {
       expect(canAdvanceAfterCombat(input.defenders_remaining as number)).toBe(expected.advance_allowed);
-      return;
+      return true;
     }
 
     // 25.13.2
     if ('advance_choice_options' in expected) {
       expect(getAdvanceChoiceOptions()).toEqual(expected.advance_choice_options);
-      return;
+      return true;
     }
 
     // 25.13.3 / 25.13.4
     if ('advance_allowed_hexes' in expected) {
       const isSiegeRelief = (input.is_siege_relief as boolean) ?? false;
       expect(getMaxAdvanceHexes(isSiegeRelief)).toBe(expected.advance_allowed_hexes);
-      return;
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/faction-classification.adapter.test.ts
+++ b/src/test/conformance/adapters/faction-classification.adapter.test.ts
@@ -10,20 +10,25 @@ import {
 runConformanceSuite(
   'chunk_1_foundations/05_faction_classification.json',
   (input, expected) => {
+    let handled = false;
+
     // Faction classification tests
     if ('faction' in input && 'classification' in expected) {
+      handled = true;
       const faction = input.faction as string;
       expect(getFactionClassification(faction)).toBe(expected.classification);
     }
 
     // Unit type classification (mercenaries)
     if ('unit_type' in input && 'classification' in expected) {
+      handled = true;
       const unitType = input.unit_type as string;
       expect(getUnitClassification(unitType)).toBe(expected.classification);
     }
 
     // Retreat success rolls
     if ('classification' in input && 'retreat_success_rolls' in expected) {
+      handled = true;
       const classification = input.classification as 'human' | 'non_human';
       expect(getRetreatSuccessRolls(classification)).toEqual(
         expected.retreat_success_rolls,
@@ -32,6 +37,7 @@ runConformanceSuite(
 
     // Retreat roll tests
     if ('retreat_roll' in input && 'retreat_successful' in expected) {
+      handled = true;
       const classification = input.classification as 'human' | 'non_human';
       const roll = input.retreat_roll as number;
       expect(isRetreatSuccessful(classification, roll)).toBe(
@@ -41,9 +47,12 @@ runConformanceSuite(
 
     // Mercenary retreat rolls
     if ('unit_type' in input && 'retreat_success_rolls' in expected) {
+      handled = true;
       expect(getRetreatSuccessRolls('human')).toEqual(
         expected.retreat_success_rolls,
       );
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/adapters/friendly-location.adapter.test.ts
+++ b/src/test/conformance/adapters/friendly-location.adapter.test.ts
@@ -16,6 +16,9 @@ runConformanceSuite(
           | undefined,
       });
       expect(result).toBe(expected.friendly);
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/leaders.adapter.test.ts
+++ b/src/test/conformance/adapters/leaders.adapter.test.ts
@@ -10,12 +10,15 @@ import {
   canMoveIndependentlyAfterLeaderMove,
   doTerrainBonusesTransferToLeader,
   getLeaderCombatBonus,
+  getLeaderAdjustedCombatValue,
   getTotalLeaderCombatBonus,
   doesLeaderBonusApplyToSiege,
   canLoneLeaderPassThroughEnemy,
   doesPassThroughRequireFateRoll,
   isFateRollRequired,
   resolveFateRoll,
+  getFateOutcomeEffect,
+  rollLeaderFateWithSeed,
   isAdditionalFateRollRequired,
   canEnterLoneLeaderHex,
   canAttackLoneLeader,
@@ -29,7 +32,7 @@ runConformanceSuite(
       expect(isLeaderUnit(input.unit_type as string)).toBe(
         expected.is_leader,
       );
-      return;
+      return true;
     }
 
     // 26.2 - Leader combat strength
@@ -37,7 +40,7 @@ runConformanceSuite(
       expect(getLeaderCombatStrength(input.unit_type as string)).toBe(
         expected.combat_strength,
       );
-      return;
+      return true;
     }
 
     // 26.3.1 - Leader bonus scope
@@ -45,7 +48,7 @@ runConformanceSuite(
       expect(
         doesLeaderBonusApply(input.stack_contains as string[]),
       ).toBe(expected.movement_bonus_applies);
-      return;
+      return true;
     }
 
     // 26.3.2 - Stack uses leader MA
@@ -57,7 +60,7 @@ runConformanceSuite(
           input.stacked_with_leader as boolean,
         ),
       ).toBe(expected.effective_movement_allowance);
-      return;
+      return true;
     }
 
     // 26.3.3 - Must begin and end with leader
@@ -68,7 +71,7 @@ runConformanceSuite(
           input.ended_turn_with_leader as boolean,
         ),
       ).toBe(expected.used_leader_bonus);
-      return;
+      return true;
     }
 
     // 26.3.4 - Leave behind
@@ -76,7 +79,7 @@ runConformanceSuite(
       expect(canLeaveBehindDuringLeaderMove()).toBe(
         expected.leave_behind_allowed,
       );
-      return;
+      return true;
     }
 
     // 26.3.5 - No independent movement after leader move
@@ -89,7 +92,7 @@ runConformanceSuite(
           input.used_leader_movement as boolean,
         ),
       ).toBe(expected.independent_movement_allowed);
-      return;
+      return true;
     }
 
     // 26.3.6 - Terrain bonuses don't transfer
@@ -97,7 +100,23 @@ runConformanceSuite(
       expect(doTerrainBonusesTransferToLeader()).toBe(
         expected.leader_gains_tree_symbol,
       );
-      return;
+      return true;
+    }
+
+    // 26.4.1 - Bonus applied to resolution
+    if ('total_combat_value' in expected) {
+      const result = getLeaderAdjustedCombatValue(
+        input.stack_base_strength as number,
+        input.stack_combat_roll as number,
+        input.personality_card_combat_bonus as number,
+      );
+      expect(result).toBe(expected.total_combat_value);
+      expect(
+        result !==
+          (input.stack_base_strength as number) +
+            (input.stack_combat_roll as number),
+      ).toBe(expected.bonus_included_in_roll);
+      return true;
     }
 
     // 26.4.1 - Leader combat bonus
@@ -107,7 +126,7 @@ runConformanceSuite(
           input.personality_card_combat_bonus as number,
         ),
       ).toBe(expected.combat_bonus);
-      return;
+      return true;
     }
 
     // 26.4.2 - Multiple bonuses stack
@@ -118,13 +137,13 @@ runConformanceSuite(
       expect(getTotalLeaderCombatBonus(leaders)).toBe(
         expected.total_combat_bonus,
       );
-      return;
+      return true;
     }
 
     // 26.4.3 - No bonus in siege
     if ('bonus_applied' in expected && input.combat_type === 'siege') {
       expect(doesLeaderBonusApplyToSiege()).toBe(expected.bonus_applied);
-      return;
+      return true;
     }
 
     // 26.5.1 - Lone leader pass through
@@ -132,7 +151,7 @@ runConformanceSuite(
       expect(
         canLoneLeaderPassThroughEnemy(input.is_alone as boolean),
       ).toBe(expected.pass_through_allowed);
-      return;
+      return true;
     }
 
     // 26.5.2 - Pass through requires fate roll
@@ -147,7 +166,7 @@ runConformanceSuite(
           input.passed_through_enemy as boolean,
         ),
       ).toBe(expected.fate_roll_required);
-      return;
+      return true;
     }
 
     // 26.6.1 - Fate roll required (various triggers)
@@ -179,7 +198,39 @@ runConformanceSuite(
           fleetLostAtSea: input.fleet_lost_at_sea as boolean | undefined,
         }),
       ).toBe(expected.fate_roll_required);
-      return;
+      return true;
+    }
+
+    // 26.6 - Deterministic seeded fate
+    if ('deterministic' in expected) {
+      const first = rollLeaderFateWithSeed(input.rng_seed as string | number);
+      const second = rollLeaderFateWithSeed(input.rng_seed as string | number);
+      const consistent = first.roll === second.roll && first.outcome === second.outcome;
+      expect(consistent).toBe(expected.roll_result_consistent_across_runs);
+      expect(consistent).toBe(expected.deterministic);
+      return true;
+    }
+
+    // 26.6.2 - Fate outcome effects
+    if ('leader_removed_from_map' in expected) {
+      const effect = getFateOutcomeEffect(input.outcome as 'killed' | 'no_effect' | 'captured');
+      expect(effect.removedFromMap).toBe(expected.leader_removed_from_map);
+      if ('leader_permanently_eliminated' in expected) {
+        expect(effect.removedFromGame).toBe(expected.leader_permanently_eliminated);
+        expect(!effect.removedFromGame).toBe(expected.leader_available_for_play);
+      }
+      if ('leader_held_by' in expected) {
+        expect(
+          effect.heldByCaptor ? input.capturing_player : null,
+        ).toBe(expected.leader_held_by);
+        expect(effect.ransomEligible).toBe(expected.ransom_eligible);
+      }
+      if ('leader_hex' in expected) {
+        expect(effect.remainsInPlace).toBe(true);
+        expect(input.leader_hex).toEqual(expected.leader_hex);
+        expect(expected.leader_status).toBe('active');
+      }
+      return true;
     }
 
     // 26.6.2 - Fate roll outcomes
@@ -187,7 +238,7 @@ runConformanceSuite(
       expect(resolveFateRoll(input.fate_roll as number)).toBe(
         expected.outcome,
       );
-      return;
+      return true;
     }
 
     // 26.6.3 - Once per phase
@@ -199,7 +250,7 @@ runConformanceSuite(
       expect(isAdditionalFateRollRequired(rollsThisPhase)).toBe(
         expected.additional_roll_required,
       );
-      return;
+      return true;
     }
 
     // 26.6.5 - Enter lone leader hex
@@ -209,13 +260,15 @@ runConformanceSuite(
       );
       expect(result.entryAllowed).toBe(expected.entry_allowed);
       expect(result.fateRollTriggered).toBe(expected.fate_roll_triggered);
-      return;
+      return true;
     }
 
     // 26.7 - Cannot attack lone leader
     if ('combat_attack_allowed' in expected) {
       expect(canAttackLoneLeader()).toBe(expected.combat_attack_allowed);
-      return;
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/movement.adapter.test.ts
+++ b/src/test/conformance/adapters/movement.adapter.test.ts
@@ -28,19 +28,19 @@ runConformanceSuite(
           input.moving_player as string,
         ),
       ).toBe(expected.movement_allowed);
-      return;
+      return true;
     }
 
     // 18.1.2 - Any direction
     if ('movement_directions' in input) {
       expect(canMoveAnyDirection()).toBe(expected.movement_allowed);
-      return;
+      return true;
     }
 
     // 18.1.3 - No saving MP
     if ('next_turn_bonus' in input) {
       expect(canSaveMovementPoints()).toBe(expected.bonus_applied);
-      return;
+      return true;
     }
 
     // 18.1.4 - Minimum movement
@@ -53,7 +53,7 @@ runConformanceSuite(
       expect(result.minimumMovementApplies).toBe(
         expected.minimum_movement_applies,
       );
-      return;
+      return true;
     }
 
     // 18.2.x / 18.3.x - Unit movement eligibility
@@ -79,7 +79,7 @@ runConformanceSuite(
             | undefined,
         }),
       ).toBe(expected.movement_allowed);
-      return;
+      return true;
     }
 
     // 18.4.1 - Stack speed
@@ -90,13 +90,13 @@ runConformanceSuite(
       expect(getStackMovementAllowance(units)).toBe(
         expected.stack_movement_allowance,
       );
-      return;
+      return true;
     }
 
     // 18.4.2 - Leave stack
     if ('leave_allowed' in expected) {
       expect(canLeaveStack()).toBe(expected.leave_allowed);
-      return;
+      return true;
     }
 
     // 18.4.3 - Independent movement after leaving
@@ -104,19 +104,19 @@ runConformanceSuite(
       expect(canContinueIndependently(input.remaining_mp as number)).toBe(
         expected.independent_movement_allowed,
       );
-      return;
+      return true;
     }
 
     // 18.5.1 - Cannot enter enemy hex
     if ('entry_allowed' in expected && 'target_hex_contains' in input) {
       expect(canEnterEnemyOccupiedHex()).toBe(expected.entry_allowed);
-      return;
+      return true;
     }
 
     // 18.5.2 - Allied stacking end of turn
     if ('position_allowed' in expected) {
       expect(canEndTurnWithAlliedKingdom()).toBe(expected.position_allowed);
-      return;
+      return true;
     }
 
     // 18.5.3 - Exceeding allowance
@@ -127,7 +127,7 @@ runConformanceSuite(
           input.movement_spent as number,
         ),
       ).toBe(expected.movement_allowed);
-      return;
+      return true;
     }
 
     // 18.5.4 - Terrain cost vs remaining
@@ -143,7 +143,7 @@ runConformanceSuite(
           expected.minimum_movement_applies,
         );
       }
-      return;
+      return true;
     }
 
     // 18.5.5 - Hexside crossing
@@ -154,7 +154,7 @@ runConformanceSuite(
           input.hexside_type as string,
         ),
       ).toBe(expected.crossing_allowed);
-      return;
+      return true;
     }
 
     // 18.5.6 - Off-map
@@ -168,7 +168,9 @@ runConformanceSuite(
       if ('movement_allowed' in expected) {
         expect(result.movementAllowed).toBe(expected.movement_allowed);
       }
-      return;
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/sieges.adapter.test.ts
+++ b/src/test/conformance/adapters/sieges.adapter.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest';
 import { runConformanceSuite } from '../harness';
+import { hexDistance } from '@/engine/map/hex-utils';
 import * as sc from '@/engine/siege/siege-check';
 import * as sr from '@/engine/siege/siege-resolution';
 
@@ -9,44 +10,58 @@ runConformanceSuite(
     // 17.1.1 - Surrounding
     if ('surrounding_requirement_met' in expected) {
       expect(sc.isCastleSurrounded(input.adjacent_hexes_covered as number, input.total_adjacent_hexes as number)).toBe(expected.surrounding_requirement_met);
-      return;
+      return true;
     }
     if ('reason' in expected && expected.reason === 'castle_not_surrounded') {
       expect(sc.isCastleSurrounded(input.adjacent_hexes_covered as number, input.total_adjacent_hexes as number)).toBe(false);
-      return;
+      return true;
     }
 
     // 17.1.2
     if ('reason' in expected && expected.reason === 'defenders_outside_castle') {
       expect(sc.hasOutsideDefenders(input.defending_units_outside as number)).toBe(true);
-      return;
+      return true;
     }
 
     // 17.1.3
+    if ('besieging_strength' in expected) {
+      const adjacentUnits = input.adjacent_units as Array<{ owner: string; strength: number }>;
+      const besiegingStrength = sc.getBesiegingStrength(adjacentUnits, 'besieger');
+      const totalStrength = adjacentUnits.reduce((sum, unit) => sum + unit.strength, 0);
+      expect(besiegingStrength).toBe(expected.besieging_strength);
+      expect(totalStrength - besiegingStrength).toBe(expected.enemy_strength_excluded);
+      const force = sc.hasSufficientForce(
+        besiegingStrength,
+        input.intrinsic_defense as number,
+        input.units_inside as number,
+      );
+      expect(force.sufficient).toBe(expected.siege_allowed);
+      return true;
+    }
     if ('required_minimum' in expected) {
       const r = sc.hasSufficientForce(input.besieging_units as number, input.intrinsic_defense as number, input.units_inside as number);
       expect(r.sufficient).toBe(expected.siege_allowed);
       expect(r.requiredMinimum).toBe(expected.required_minimum);
-      return;
+      return true;
     }
     if ('siege_allowed' in expected && 'besieging_units' in input && 'intrinsic_defense' in input && 'units_inside' in input && !('reason' in expected)) {
       const r = sc.hasSufficientForce(input.besieging_units as number, input.intrinsic_defense as number, input.units_inside as number);
       expect(r.sufficient).toBe(expected.siege_allowed);
-      return;
+      return true;
     }
 
     // 17.2
     if ('combined_siege_allowed' in expected) {
       expect(sc.canCombineSiege()).toBe(expected.combined_siege_allowed);
       expect(sc.canConductSeparateSieges()).toBe(expected.separate_sieges_possible);
-      return;
+      return true;
     }
 
     // 17.3.1 - Zone of siege (geometry - we validate the concept)
     if ('zone_of_siege_hexes' in expected) {
       // Zone concept validated by surrounding test; specific hex calculation deferred to map module
       expect(Array.isArray(expected.zone_of_siege_hexes)).toBe(true);
-      return;
+      return true;
     }
 
     // 17.3.2
@@ -54,7 +69,7 @@ runConformanceSuite(
       const r = sc.getFleetZoneTerrains(input.adjacent_terrain as string[]);
       expect(r.extendsTo).toEqual(expected.zone_extends_to);
       expect(r.excludes).toEqual(expected.zone_excludes);
-      return;
+      return true;
     }
 
     // 17.3.3
@@ -62,120 +77,189 @@ runConformanceSuite(
       const r = sc.getLandZoneTerrains(input.adjacent_terrain as string[]);
       expect(r.extendsTo.sort()).toEqual((expected.zone_extends_to as string[]).sort());
       expect(r.excludes.sort()).toEqual((expected.zone_excludes as string[]).sort());
-      return;
+      return true;
     }
 
     // 17.3.4
     if ('zone_negated' in expected) {
       expect(sc.doesFriendlyNegateZone()).toBe(expected.zone_negated);
-      return;
+      return true;
     }
 
     // 17.4.1
     if ('counter_state' in expected) {
       expect(sc.getCounterState()).toBe(expected.counter_state);
-      return;
+      return true;
     }
 
     // 17.4.2
     if ('siege_declaration_valid' in expected) {
       expect(sc.isSiegeDeclarationValid(input.outside_defenders_present as boolean)).toBe(expected.siege_declaration_valid);
-      return;
+      return true;
     }
 
     // 17.4.4
     if ('retreat_allowed' in expected && 'retreat_destination' in input) {
       expect(sc.canRetreatIntoCastle(input.castle_friendly as boolean)).toBe(expected.retreat_allowed);
-      return;
+      return true;
     }
 
     // 17.4.5
     if ('leader_combat_bonus_applies' in expected) {
       expect(sc.doesLeaderInsideBonusApplyOutside()).toBe(expected.leader_combat_bonus_applies);
-      return;
+      return true;
     }
 
     // 17.4.6
     if ('movement_cost' in expected && input.movement_type === 'enter_castle') {
       expect(sc.getCastleMovementCost()).toBe(expected.movement_cost);
-      return;
+      return true;
     }
 
     // 17.5.1
     if ('intrinsic_defense_strength' in expected && 'printed_defense' in input) {
       expect(sc.getIntrinsicDefense(input.printed_defense as number)).toBe(expected.intrinsic_defense_strength);
-      return;
+      return true;
     }
 
     // 17.5.2
     if ('intrinsic_strength_applies' in expected) {
       expect(sc.doesIntrinsicApplyToAttack()).toBe(expected.intrinsic_strength_applies);
-      return;
+      return true;
     }
 
     // 17.5.3
     if ('entry_allowed' in expected && 'castle_status' in input && input.castle_status === 'intact') {
       expect(sc.canEnemyEnterIntactCastle(input.entering_unit as string)).toBe(expected.entry_allowed);
-      return;
+      return true;
     }
 
     // 17.5.4
     if ('intrinsic_defense_strength' in expected && input.castle_status === 'plundered') {
       expect(sc.getPlunderedDefense()).toBe(expected.intrinsic_defense_strength);
-      return;
+      return true;
+    }
+
+    // 17.6 - Siege persistence
+    if ('siege_valid' in expected) {
+      const result = sc.isSiegeStillValid({
+        siegeActive: input.siege_active as boolean,
+        adjacentHexesCovered: input.adjacent_hexes_covered as number,
+        totalAdjacentHexes: input.total_adjacent_hexes as number,
+        besiegingUnits: input.besieging_units as number,
+        intrinsicDefense: input.intrinsic_defense as number,
+        unitsInside: input.units_inside as number,
+      });
+      expect(result.siegeValid).toBe(expected.siege_valid);
+      expect(result.siegeEnds).toBe(expected.siege_ends);
+      expect(result.reason).toBe(expected.reason);
+      return true;
     }
 
     // 17.6.1
     if ('siege_declaration' in expected) {
       expect(sc.getSiegeDeclarationType(input.surrounded as boolean, input.no_outside_defenders as boolean, input.sufficient_force as boolean)).toBe(expected.siege_declaration);
-      return;
+      return true;
     }
 
     // 17.6.2
     if ('declaration_valid' in expected) {
       expect(sc.canAnyPlayerDeclare()).toBe(expected.declaration_valid);
-      return;
+      return true;
     }
 
     // 17.6.3
     if ('counts_as_besieging' in expected) {
       expect(sc.doesRetreatedUnitCountAsBesieging()).toBe(expected.counts_as_besieging);
-      return;
+      return true;
     }
 
     // 17.7.1
     if ('entry_allowed' in expected && input.castle_status === 'besieged') {
       expect(sc.canReinforceBesiegedCastle()).toBe(expected.entry_allowed);
-      return;
+      return true;
+    }
+
+    // 17.7.2 - Breakout specifics
+    if ('breakout_allowed' in expected && 'attempt_breakout' in input) {
+      const breakout = sc.canAttemptBreakout((input.units_inside as string[]).length);
+      expect(breakout.breakoutAllowed).toBe(expected.breakout_allowed);
+      if ('reason' in expected) {
+        expect(breakout.reason).toBe(expected.reason);
+      }
+      if ('must_fight_all_besiegers' in expected) {
+        const rules = sc.getBreakoutCombatRules();
+        expect(rules.mustFightAllBesiegers).toBe(expected.must_fight_all_besiegers);
+        expect(rules.combatType).toBe(expected.combat_type);
+      }
+      return true;
+    }
+    if ('movement_options_include' in expected) {
+      const result = sc.getBreakoutMovementOptions(
+        input.cleared_adjacent_hexes as number[][],
+        input.survivors as string[],
+      );
+      expect(result.movementOptionsInclude).toEqual(expected.movement_options_include);
+      expect(result.survivorsMayMove).toBe(expected.survivors_may_move);
+      return true;
     }
 
     // 17.7.2 - Leaving siege
     if ('exit_allowed' in expected && 'attack_besiegers' in input) {
       expect(sc.canLeaveSiegeWithoutAttack()).toBe(false);
       expect(expected.exit_allowed).toBe(false);
-      return;
+      return true;
     }
     if ('exit_allowed' in expected && 'attacked_besiegers' in input) {
       const r = sc.canExitAfterAttack(input.attacked_besiegers as boolean);
       expect(r.exitAllowed).toBe(expected.exit_allowed);
       expect(r.movementAllowance).toBe(expected.movement_allowance);
-      return;
+      return true;
     }
 
     // 17.7.3
+    if ('sortie_allowed' in expected) {
+      const castleHex = input.castle_hex as number[];
+      const targetHex = input.target_hex as number[];
+      const targetIsAdjacent =
+        hexDistance(
+          { col: castleHex[0]!, row: castleHex[1]! },
+          { col: targetHex[0]!, row: targetHex[1]! },
+        ) === 1;
+      const result = sc.canSortieAttack(
+        targetIsAdjacent,
+        input.enemies_in_target_hex as boolean,
+        input.current_phase as string,
+        input.besieged_units_attacking as boolean,
+      );
+      expect(result.sortieAllowed).toBe(expected.sortie_allowed);
+      expect(result.targetMustBeAdjacent).toBe(expected.target_must_be_adjacent);
+      return true;
+    }
+    if ('advance_allowed' in expected && 'defender_hex_cleared' in input) {
+      expect(sc.canAdvanceAfterSortie(input.defender_hex_cleared as boolean)).toBe(
+        expected.advance_allowed,
+      );
+      return true;
+    }
     if ('attack_allowed' in expected && 'attack_timing' in input) {
       expect(sc.canBesiegedAttackInCombatPhase()).toBe(expected.attack_allowed);
-      return;
+      return true;
     }
     if ('advance_limit_hexes' in expected) {
       expect(sc.getAdvanceLimitFromSiege()).toBe(expected.advance_limit_hexes);
-      return;
+      if ('excess_movement_forfeited' in expected) {
+        expect(
+          (input.unit_remaining_movement as number) > sc.getAdvanceLimitFromSiege(),
+        ).toBe(expected.excess_movement_forfeited);
+      }
+      return true;
     }
 
     // 17.8.1
     if ('resolution_allowed' in expected) {
       expect(sr.canResolveSiege(input.current_phase as string, input.active_player as string, '')).toBe(expected.resolution_allowed);
-      return;
+      return true;
     }
 
     // 17.8.2
@@ -183,7 +267,7 @@ runConformanceSuite(
       const r = sr.getSiegeDieInfo();
       expect(r.dieType).toBe(expected.die_type);
       expect(r.diceCount).toBe(expected.dice_count);
-      return;
+      return true;
     }
 
     // 17.8.3-4 - Siege roll results
@@ -194,7 +278,7 @@ runConformanceSuite(
       if ('siege_continues' in expected) expect(r.siegeContinues).toBe(expected.siege_continues);
       if ('units_inside_eliminated' in expected) expect(r.unitsInsideEliminated).toBe(expected.units_inside_eliminated);
       if ('leaders_require_fate_roll' in expected) expect(r.leadersRequireFateRoll).toBe(expected.leaders_require_fate_roll);
-      return;
+      return true;
     }
 
     // 17.8.5
@@ -202,115 +286,127 @@ runConformanceSuite(
       const r = sr.canActAfterSiegeAttack();
       expect(r.furtherMovementAllowed).toBe(expected.further_movement_allowed);
       expect(r.furtherAttackAllowed).toBe(expected.further_attack_allowed);
-      return;
+      return true;
     }
 
     // 17.9.x - Siege modifier
     if ('modifier' in expected && 'besieging_units' in input) {
       expect(sr.calculateSiegeModifier(input.besieging_units as number, input.intrinsic_defense as number, input.units_inside as number)).toBe(expected.modifier);
-      return;
+      return true;
     }
 
     // 17.10.x - Plundered
+    if ('victory_points_awarded' in expected) {
+      expect(
+        sr.getPlunderVictoryPoints(
+          input.castle_type as 'regular' | 'royal',
+          input.castle_defense_value as number,
+          input.action as 'plunder' | 'capture',
+        ),
+      ).toBe(expected.victory_points_awarded);
+      return true;
+    }
     if ('siege_rules_apply' in expected && input.castle_status === 'plundered') {
       const r = sr.getPlunderedCastleRules();
       expect(r.siegeRulesApply).toBe(expected.siege_rules_apply);
       expect(r.castleDefenseApplies).toBe(expected.castle_defense_applies);
-      return;
+      return true;
     }
     if ('placement_allowed' in expected) {
       expect(sr.canPlacementInPlundered()).toBe(expected.placement_allowed);
-      return;
+      return true;
     }
     if ('friendly_for_deployment' in expected) {
       expect(sr.isOccupiedPlunderedFriendly()).toBe(expected.friendly_for_deployment);
-      return;
+      return true;
     }
     if ('still_plundered' in expected) {
       expect(sr.isPlunderPermanent()).toBe(true);
       expect(expected.status_changed).toBe(false);
-      return;
+      return true;
     }
 
     // 17.11.x - Fleet siege
     if ('total_besieging_strength' in expected) {
       expect(sr.getTotalSiegeStrength(input.besieging_armies as number, input.besieging_fleets as number)).toBe(expected.total_besieging_strength);
-      return;
+      return true;
     }
     if ('fleet_attack_allowed' in expected) {
       expect(sr.canFleetAttackAllLand()).toBe(expected.fleet_attack_allowed);
-      return;
+      return true;
     }
     if ('reason' in expected && expected.reason === 'port_requires_fleet') {
       expect(sr.doesPortRequireFleet()).toBe(true);
-      return;
+      return true;
     }
     if ('reason' in expected && expected.reason === 'sea_hexes_not_covered') {
       expect(sr.areSeaHexesCovered(input.adjacent_sea_hexes as number, input.sea_hexes_covered as number)).toBe(false);
-      return;
+      return true;
     }
     if ('total_siege_strength' in expected) {
       expect(sr.getTotalSiegeWithSeaborne(input.fleets as number, input.units_aboard_fleets as number, input.land_units as number)).toBe(expected.total_siege_strength);
-      return;
+      return true;
     }
     if ('zone_of_siege' in expected && input.status === 'aboard_fleet') {
       expect(sr.doSeaborneExhibitZoneOfSiege()).toBe(expected.zone_of_siege);
-      return;
+      return true;
     }
 
     // 17.12.x - Relief
     if ('advance_into_castle_allowed' in expected) {
       expect(sr.canAdvanceIntoCastleAfterRelief()).toBe(expected.advance_into_castle_allowed);
-      return;
+      return true;
     }
     if ('advance_allowed_hexes' in expected && 'castle_surrounded' in input) {
       expect(sr.getReliefAdvanceHexes(input.castle_surrounded as boolean)).toBe(expected.advance_allowed_hexes);
-      return;
+      return true;
     }
     if ('position_options' in expected) {
       expect(sr.getReliefPositionOptions()).toEqual(expected.position_options);
-      return;
+      return true;
     }
 
     // 17.13.x - Forced peace
     if ('forced_peace_eligible' in expected) {
       expect(sr.isForcedPeaceEligible(input.castle_type as string, input.castle_status as string, input.occupied_by as string)).toBe(expected.forced_peace_eligible);
-      return;
+      return true;
     }
     if ('roll_type' in expected) {
       const r = sr.getForcedPeaceRollType();
       expect(r.rollType).toBe(expected.roll_type);
       expect(r.die).toBe(expected.die);
-      return;
+      return true;
     }
     if ('forced_peace_success' in expected) {
       expect(sr.isForcedPeaceSuccessful(input.forced_peace_roll as number, input.contested as boolean)).toBe(expected.forced_peace_success);
-      return;
+      return true;
     }
     if ('modifiers_applied' in expected && 'diplomacy_card_modifier' in input) {
       const r = sr.getForcedPeaceModifiedRoll(input.forced_peace_roll as number, input.diplomacy_card_modifier as number, input.diplomatic_penalty as number);
       expect(r.modifiedRoll).toBe(expected.modified_roll);
       expect(r.modifiersApplied).toBe(expected.modifiers_applied);
-      return;
+      return true;
     }
     if ('forced_peace_duration' in expected) {
       expect(sr.getForcedPeaceDuration(input.duration_roll as number)).toBe(expected.forced_peace_duration);
-      return;
+      return true;
     }
     if ('diplomacy_allowed' in expected && input.kingdom_status === 'forced_peace') {
       expect(sr.canDiplomacyDuringForcedPeace()).toBe(expected.diplomacy_allowed);
-      return;
+      return true;
     }
     if ('forced_peace_ends' in expected) {
       const r = sr.handleForcedPeaceViolation();
       expect(r.diplomaticPenaltyIncurred).toBe(expected.diplomatic_penalty_incurred);
       expect(r.forcedPeaceEnds).toBe(expected.forced_peace_ends);
       expect(r.kingdomAvailableImmediately).toBe(expected.kingdom_available_immediately);
-      return;
+      return true;
     }
     if ('forced_peace_applicable' in expected) {
       expect(sr.isPlayerMonarchSubjectToForcedPeace()).toBe(expected.forced_peace_applicable);
-      return;
+      return true;
     }
+
+    return false;
   },
 );

--- a/src/test/conformance/adapters/stacking.adapter.test.ts
+++ b/src/test/conformance/adapters/stacking.adapter.test.ts
@@ -17,42 +17,53 @@ import {
 runConformanceSuite(
   'chunk_6_supporting/24_stacking.json',
   (input, expected) => {
+    let handled = false;
+
     if ('stack_limit' in expected) {
+      handled = true;
       expect(getSameKingdomStackLimit()).toBe(expected.stack_limit);
     }
 
     if ('hex_sharing_allowed' in expected) {
+      handled = true;
       expect(canSameKingdomShareHex()).toBe(expected.hex_sharing_allowed);
     }
 
     if ('pass_through_allowed' in expected) {
+      handled = true;
       expect(canAlliedPassThrough()).toBe(expected.pass_through_allowed);
     }
 
     if ('end_turn_allowed' in expected) {
+      handled = true;
       expect(canAlliedEndTurnTogether()).toBe(expected.end_turn_allowed);
     }
 
     if ('stacking_allowed' in expected && 'mercenary_unit' in input) {
+      handled = true;
       expect(canMercenaryStackWithFriendly()).toBe(expected.stacking_allowed);
     }
 
     if ('movement_penalty' in expected) {
+      handled = true;
       expect(getMercenaryStackTransferPenalty()).toBe(
         expected.movement_penalty,
       );
     }
 
     if ('stacking_rules' in expected) {
+      handled = true;
       expect(getFleetStackingRules()).toBe(expected.stacking_rules);
     }
 
     if ('entry_allowed' in expected && 'allied_castle' in input) {
+      handled = true;
       const present = input.allied_combat_units_present as number;
       expect(canEnterAlliedCastle(present)).toBe(expected.entry_allowed);
     }
 
     if ('defense_allowed' in expected && 'entry_allowed' in input) {
+      handled = true;
       const entryAllowed = input.entry_allowed as boolean;
       expect(canDefendAlliedCastle(entryAllowed)).toBe(
         expected.defense_allowed,
@@ -64,12 +75,16 @@ runConformanceSuite(
       'allied_castle' in input &&
       'allied_units_present' in input
     ) {
+      handled = true;
       const present = input.allied_units_present as boolean;
       expect(canStackInAlliedCastle(present)).toBe(expected.stacking_allowed);
     }
 
     if ('inspection_allowed' in expected) {
+      handled = true;
       expect(canInspectOpponentStack()).toBe(expected.inspection_allowed);
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/adapters/terrain-capabilities.adapter.test.ts
+++ b/src/test/conformance/adapters/terrain-capabilities.adapter.test.ts
@@ -11,12 +11,15 @@ import {
 runConformanceSuite(
   'chunk_1_foundations/06_terrain_capabilities.json',
   (input, expected) => {
+    let handled = false;
+
     const abilities: TerrainAbilities = {
       hasTreeSymbol: (input.unit_has_tree_symbol as boolean) ?? false,
       hasMountainSymbol: (input.unit_has_mountain_symbol as boolean) ?? false,
     };
 
     if ('effective_terrain' in expected && 'terrain' in input) {
+      handled = true;
       const terrain = input.terrain as string;
       expect(getEffectiveTerrain(terrain, abilities)).toBe(
         expected.effective_terrain,
@@ -24,6 +27,7 @@ runConformanceSuite(
     }
 
     if ('movement_cost' in expected && 'terrain' in input) {
+      handled = true;
       const terrain = input.terrain as string;
       expect(getTerrainMovementCost(terrain, abilities)).toBe(
         expected.movement_cost,
@@ -31,11 +35,13 @@ runConformanceSuite(
     }
 
     if ('must_stop' in expected && 'terrain' in input) {
+      handled = true;
       const terrain = input.terrain as string;
       expect(mustStopInTerrain(terrain, abilities)).toBe(expected.must_stop);
     }
 
     if ('has_home_kingdom_bonus' in expected) {
+      handled = true;
       const unitType = input.unit_type as string;
       const inHome = input.in_home_kingdom as boolean;
       expect(hasHomeKingdomBonus(unitType, inHome)).toBe(
@@ -44,11 +50,14 @@ runConformanceSuite(
     }
 
     if ('effective_tree_symbol' in expected) {
+      handled = true;
       const unitType = input.unit_type as string;
       const inHome = input.in_home_kingdom as boolean;
       const hasBonus = hasHomeKingdomBonus(unitType, inHome);
       expect(hasBonus).toBe(expected.effective_tree_symbol);
       expect(hasBonus).toBe(expected.effective_mountain_symbol);
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/adapters/terrain.adapter.test.ts
+++ b/src/test/conformance/adapters/terrain.adapter.test.ts
@@ -18,6 +18,7 @@ import {
 runConformanceSuite(
   'chunk_1_foundations/19_terrain.json',
   (input, expected) => {
+    let handled = false;
     const rawTerrain = input.terrain;
     const abilities: TerrainAbilities = {
       hasTreeSymbol: (input.unit_has_tree_symbol as boolean) ?? false,
@@ -29,23 +30,26 @@ runConformanceSuite(
       const terrains = rawTerrain as string[];
 
       if ('movement_cost' in expected) {
+        handled = true;
         expect(calculateCumulativeTerrainCost(terrains, abilities)).toBe(
           expected.movement_cost,
         );
       }
 
       if ('must_stop' in expected) {
+        handled = true;
         expect(mustStopInCumulativeTerrain(terrains, abilities)).toBe(
           expected.must_stop,
         );
       }
-      return;
+      return handled;
     }
 
     const terrain = rawTerrain as string;
 
     // Simple movement cost
     if ('movement_cost' in expected && !('combat_role' in input)) {
+      handled = true;
       if (input.unit_has_tree_symbol || input.unit_has_mountain_symbol) {
         expect(getTerrainMovementCost(terrain, abilities)).toBe(
           expected.movement_cost,
@@ -59,11 +63,13 @@ runConformanceSuite(
 
     // Must stop
     if ('must_stop' in expected) {
+      handled = true;
       expect(mustStopInTerrain(terrain, abilities)).toBe(expected.must_stop);
     }
 
     // Combat modifier (defender bonus)
     if ('combat_modifier' in expected) {
+      handled = true;
       const role = input.combat_role as 'attacker' | 'defender';
       expect(getTerrainCombatModifier(terrain, role)).toBe(
         expected.combat_modifier,
@@ -72,6 +78,7 @@ runConformanceSuite(
 
     // Effective combat value (mountain pass doubles)
     if ('effective_combat_value' in expected) {
+      handled = true;
       const role = input.combat_role as 'attacker' | 'defender';
       const baseValue = input.base_combat_value as number;
       expect(getEffectiveCombatValue(terrain, role, baseValue)).toBe(
@@ -81,6 +88,7 @@ runConformanceSuite(
 
     // Hexside crossing
     if ('crossing_allowed' in expected && 'hexside_type' in input) {
+      handled = true;
       const unitCat = input.unit_type as 'land' | 'fleet';
       const hexside = input.hexside_type as string;
       expect(canCrossHexside(unitCat, hexside)).toBe(
@@ -90,12 +98,14 @@ runConformanceSuite(
 
     // Major river crossing
     if ('crossing_allowed' in expected && 'crossing_major_river' in input) {
+      handled = true;
       const beganInHex = input.began_in_hex as boolean;
       expect(canCrossMajorRiver(beganInHex)).toBe(expected.crossing_allowed);
     }
 
     // Entry allowed
     if ('entry_allowed' in expected) {
+      handled = true;
       const unitCat = input.unit_type === 'fleet' ? 'fleet' : 'land' as const;
       expect(
         canEnterTerrain(terrain, unitCat, {
@@ -112,9 +122,12 @@ runConformanceSuite(
 
     // Terrain access (seaport)
     if ('fleet_access' in expected) {
+      handled = true;
       const access = getTerrainAccess(terrain);
       expect(access.fleetAccess).toBe(expected.fleet_access);
       expect(access.landAccess).toBe(expected.land_access);
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/adapters/unit-types.adapter.test.ts
+++ b/src/test/conformance/adapters/unit-types.adapter.test.ts
@@ -13,35 +13,43 @@ import {
 runConformanceSuite(
   'chunk_1_foundations/04_unit_types.json',
   (input, expected) => {
+    let handled = false;
     const unitType = input.unit_type as string;
 
     if ('is_combat_unit' in expected) {
+      handled = true;
       expect(isCombatUnit(unitType)).toBe(expected.is_combat_unit);
     }
 
     if ('is_leader' in expected) {
+      handled = true;
       expect(isLeader(unitType)).toBe(expected.is_leader);
     }
 
     if ('combat_strength' in expected) {
+      handled = true;
       expect(getCombatStrength(unitType)).toBe(expected.combat_strength);
     }
 
     if ('transport_capacity' in expected) {
+      handled = true;
       expect(getTransportCapacity(unitType)).toBe(expected.transport_capacity);
     }
 
     if ('movement_type' in expected) {
+      handled = true;
       expect(getMovementType(unitType)).toBe(expected.movement_type);
     }
 
     if ('player_eliminated' in expected) {
+      handled = true;
       const monarchType = input.monarch_type as 'player' | 'non_player';
       const effect = getMonarchDeathEffect(monarchType);
       expect(effect.playerEliminated).toBe(expected.player_eliminated);
     }
 
     if ('kingdom_enters_confusion' in expected) {
+      handled = true;
       const monarchType = input.monarch_type as 'player' | 'non_player';
       const effect = getMonarchDeathEffect(monarchType);
       expect(effect.kingdomEntersConfusion).toBe(
@@ -50,7 +58,10 @@ runConformanceSuite(
     }
 
     if ('recovery_turns' in expected) {
+      handled = true;
       expect(getAmbassadorRecoveryTurns()).toBe(expected.recovery_turns);
     }
+
+    return handled;
   },
 );

--- a/src/test/conformance/harness.ts
+++ b/src/test/conformance/harness.ts
@@ -23,7 +23,7 @@ export interface ConformanceSuite {
 export type AdapterFn = (
   input: Record<string, unknown>,
   expected: Record<string, unknown>,
-) => void;
+) => boolean;
 
 /**
  * Load a conformance test suite from a JSON file.
@@ -57,7 +57,11 @@ export function runConformanceSuite(
       }
 
       it(`${test.id}: ${test.description}`, () => {
-        adapter(test.input, test.expected);
+        expect.hasAssertions();
+        const handled = adapter(test.input, test.expected);
+        if (!handled) {
+          throw new Error(`Unhandled conformance case: ${test.id}`);
+        }
       });
     }
   });


### PR DESCRIPTION
## Summary
- harden the conformance harness so unmapped JSON cases fail immediately
- add honest combat, leader, and siege helper coverage for the PR #43 scenarios
- update AGENTS.md to forbid fixture-only conformance additions without adapter/runtime wiring

## Verification
- npx vitest run src/test/conformance/adapters/combat.adapter.test.ts
- npx vitest run src/test/conformance/adapters/leaders.adapter.test.ts
- npx vitest run src/test/conformance/adapters/sieges.adapter.test.ts
- python3 scripts/validate_conformance_suite.py
- npm test
- npm run test:local:gate
